### PR TITLE
Add CLI album management with scanning and pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# iPhotos
-Bring Mac-style Photos to Windows
+# iPhoto
+
+Bring Mac-style Photos to Windows.
+
+## Features
+
+- Folder-native album management with JSON manifest files.
+- Incremental directory scanning that caches metadata in `.iPhoto/index.jsonl`.
+- Automatic Live Photo pairing stored in `.iPhoto/links.json`.
+- CLI for initialising albums, rescanning, pairing, managing covers, featured assets, and generating reports.
+
+## Getting Started
+
+```bash
+pip install -e .
+iphoto init /path/to/album
+iphoto scan /path/to/album
+iphoto pair /path/to/album
+```
+
+Use `iphoto cover set`, `iphoto feature add|rm`, and `iphoto report` for additional management tasks.

--- a/README.md
+++ b/README.md
@@ -46,3 +46,25 @@ Windows Python builds the optional `_ctypes` extension is missing, which prevent
 Pillow from importing. In that case the application skips Pillow-backed features
 and continues with basic placeholders; install a Python distribution that
 includes `_ctypes` to re-enable rich previews.
+
+### Troubleshooting PyCharm debugging
+
+If PyCharm's debugger aborts with ``ImportError: DLL load failed while importing
+_ctypes`` the active Python runtime lacks the native ``_ctypes`` extension. That
+binary ships with official CPython builds but may be absent in some Anaconda
+environments. Use the helper script to verify the requirement:
+
+```bash
+python scripts/check_debugger.py
+```
+
+When the check fails install the missing dependency and reinstall Python inside
+your environment, for example:
+
+```bash
+conda install libffi
+conda install python --force-reinstall
+```
+
+Alternatively switch the interpreter to a python.org build where ``_ctypes`` is
+always available.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ iphoto-gui /photos/LondonTrip
 Video thumbnail generation and duration metadata rely on the `ffmpeg` toolchain.
 Install `ffmpeg`/`ffprobe` and ensure they are on your `PATH` so Windows users
 receive motion previews instead of placeholders.
+
+Image metadata and HEIC decoding fall back to Pillow when available. On some
+Windows Python builds the optional `_ctypes` extension is missing, which prevents
+Pillow from importing. In that case the application skips Pillow-backed features
+and continues with basic placeholders; install a Python distribution that
+includes `_ctypes` to re-enable rich previews.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,18 @@ iphoto pair /path/to/album
 ```
 
 Use `iphoto cover set`, `iphoto feature add|rm`, and `iphoto report` for additional management tasks.
+
+### Launching the desktop UI
+
+The project ships with a PySide6-based desktop interface. After installing the
+package you can launch it with:
+
+```bash
+iphoto-gui
+```
+
+Optionally provide an album path to open immediately:
+
+```bash
+iphoto-gui /photos/LondonTrip
+```

--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ Optionally provide an album path to open immediately:
 ```bash
 iphoto-gui /photos/LondonTrip
 ```
+
+### External tools
+
+Video thumbnail generation and duration metadata rely on the `ffmpeg` toolchain.
+Install `ffmpeg`/`ffprobe` and ensure they are on your `PATH` so Windows users
+receive motion previews instead of placeholders.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "typer>=0.12",
   "rich>=13",
   "jsonschema>=4",
+  "PySide6>=6.6",
   "Pillow>=10",
   "pillow-heif>=0.16",
   "imagehash>=4",
@@ -22,6 +23,7 @@ dependencies = [
 
 [project.scripts]
 iphoto = "iPhoto.cli:app"
+iphoto-gui = "iPhoto.gui.main:main"
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "iPhoto"
+version = "0.1.0"
+description = "Folder-native photo manager with Live Photo support"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{name = "iPhoto Team"}]
+dependencies = [
+  "typer>=0.12",
+  "rich>=13",
+  "jsonschema>=4",
+  "Pillow>=10",
+  "pillow-heif>=0.16",
+  "imagehash>=4",
+  "xxhash>=3",
+  "python-dateutil>=2",
+]
+
+[project.scripts]
+iphoto = "iPhoto.cli:app"
+
+[tool.ruff]
+line-length = 100
+select = ["E", "F", "I", "B", "UP", "N", "ASYNC", "S", "BLE", "A", "C4", "PIE", "Q", "RUF"]
+ignore = ["E203"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"
+pythonpath = ["src"]
+
+[tool.typer]
+pretty_exceptions_enable = true

--- a/scripts/check_debugger.py
+++ b/scripts/check_debugger.py
@@ -1,0 +1,20 @@
+"""Diagnose whether the current Python build supports PyCharm debugging."""
+
+from __future__ import annotations
+
+from iPhoto.utils.deps import debugger_prerequisites
+
+
+def main() -> int:
+    info = debugger_prerequisites()
+    if info.has_ctypes:
+        print("Debugger prerequisites satisfied: `_ctypes` is available.")
+        return 0
+
+    print("PyCharm debugging prerequisites missing:\n")
+    print(info.message)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/iPhoto/app.py
+++ b/src/iPhoto/app.py
@@ -1,0 +1,79 @@
+"""High-level application facade."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from .cache.index_store import IndexStore
+from .cache.lock import FileLock
+from .config import DEFAULT_EXCLUDE, DEFAULT_INCLUDE, WORK_DIR_NAME
+from .core.pairing import pair_live
+from .models.album import Album
+from .models.types import LiveGroup
+from .utils.jsonio import write_json
+from .utils.logging import get_logger
+
+LOGGER = get_logger()
+
+
+def open_album(root: Path) -> Album:
+    """Open an album directory, scanning and pairing as required."""
+
+    album = Album.open(root)
+    store = IndexStore(root)
+    rows = list(store.read_all())
+    if not rows:
+        include = album.manifest.get("filters", {}).get("include", DEFAULT_INCLUDE)
+        exclude = album.manifest.get("filters", {}).get("exclude", DEFAULT_EXCLUDE)
+        from .io.scanner import scan_album
+
+        rows = list(scan_album(root, include, exclude))
+        store.write_rows(rows)
+    _ensure_links(root, rows)
+    return album
+
+
+def _ensure_links(root: Path, rows: List[dict]) -> None:
+    work_dir = root / WORK_DIR_NAME
+    links_path = work_dir / "links.json"
+    if links_path.exists():
+        return
+    LOGGER.info("Generating links.json for %s", root)
+    groups = pair_live(rows)
+    payload = {
+        "schema": "iPhoto/links@1",
+        "live_groups": [group.__dict__ for group in groups],
+        "clips": [],
+    }
+    with FileLock(root, "links"):
+        write_json(links_path, payload, backup_dir=work_dir / "manifest.bak")
+
+
+def rescan(root: Path) -> List[dict]:
+    """Rescan the album and return the fresh index rows."""
+
+    album = Album.open(root)
+    include = album.manifest.get("filters", {}).get("include", DEFAULT_INCLUDE)
+    exclude = album.manifest.get("filters", {}).get("exclude", DEFAULT_EXCLUDE)
+    from .io.scanner import scan_album
+
+    rows = list(scan_album(root, include, exclude))
+    IndexStore(root).write_rows(rows)
+    return rows
+
+
+def pair(root: Path) -> List[LiveGroup]:
+    """Rebuild live photo pairings from the current index."""
+
+    rows = list(IndexStore(root).read_all())
+    groups = pair_live(rows)
+    work_dir = root / WORK_DIR_NAME
+    payload = {
+        "schema": "iPhoto/links@1",
+        "live_groups": [group.__dict__ for group in groups],
+        "clips": [],
+    }
+    with FileLock(root, "links"):
+        write_json(work_dir / "links.json", payload, backup_dir=work_dir / "manifest.bak")
+    return groups

--- a/src/iPhoto/appctx.py
+++ b/src/iPhoto/appctx.py
@@ -1,0 +1,26 @@
+"""Application-wide context helpers for the GUI layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+
+from .gui.facade import AppFacade
+
+
+@dataclass
+class AppContext:
+    """Container object shared across GUI components."""
+
+    facade: AppFacade = field(default_factory=AppFacade)
+    recent_albums: List[Path] = field(default_factory=list)
+
+    def remember_album(self, root: Path) -> None:
+        """Track *root* in the recent albums list, keeping the most recent first."""
+
+        normalized = root.resolve()
+        self.recent_albums = [entry for entry in self.recent_albums if entry != normalized]
+        self.recent_albums.insert(0, normalized)
+        # Keep the list short to avoid unbounded growth.
+        del self.recent_albums[10:]

--- a/src/iPhoto/appctx.py
+++ b/src/iPhoto/appctx.py
@@ -4,16 +4,25 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List
+from typing import List, TYPE_CHECKING
 
-from .gui.facade import AppFacade
+if TYPE_CHECKING:  # pragma: no cover - only for type checking
+    from .gui.facade import AppFacade
+
+
+def _create_facade() -> "AppFacade":
+    """Factory that imports :class:`AppFacade` lazily to avoid circular imports."""
+
+    from .gui.facade import AppFacade  # Local import prevents circular dependency
+
+    return AppFacade()
 
 
 @dataclass
 class AppContext:
     """Container object shared across GUI components."""
 
-    facade: AppFacade = field(default_factory=AppFacade)
+    facade: "AppFacade" = field(default_factory=_create_facade)
     recent_albums: List[Path] = field(default_factory=list)
 
     def remember_album(self, root: Path) -> None:

--- a/src/iPhoto/cache/index_store.py
+++ b/src/iPhoto/cache/index_store.py
@@ -1,0 +1,56 @@
+"""Persistent storage for album index rows."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Iterator
+
+from ..config import WORK_DIR_NAME
+from .lock import FileLock
+from ..errors import IndexCorruptedError
+from ..utils.jsonio import atomic_write_text
+
+
+class IndexStore:
+    """Read/write helper for ``index.jsonl`` files."""
+
+    def __init__(self, album_root: Path):
+        self.album_root = album_root
+        self.path = album_root / WORK_DIR_NAME / "index.jsonl"
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def write_rows(self, rows: Iterable[Dict[str, object]]) -> None:
+        """Rewrite the entire index with *rows*."""
+
+        payload = "\n".join(json.dumps(row, ensure_ascii=False, sort_keys=True) for row in rows)
+        if payload:
+            payload += "\n"
+        with FileLock(self.album_root, "index"):
+            atomic_write_text(self.path, payload)
+
+    def read_all(self) -> Iterator[Dict[str, object]]:
+        """Yield all rows from the index."""
+
+        if not self.path.exists():
+            return iter(())
+
+        def _iterator() -> Iterator[Dict[str, object]]:
+            try:
+                with self.path.open("r", encoding="utf-8") as handle:
+                    for line in handle:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        yield json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise IndexCorruptedError(f"Corrupted index file: {self.path}") from exc
+
+        return _iterator()
+
+    def upsert_row(self, rel: str, row: Dict[str, object]) -> None:
+        """Insert or update a single row identified by *rel*."""
+
+        data = {existing["rel"]: existing for existing in self.read_all()}
+        data[rel] = row
+        self.write_rows(data.values())

--- a/src/iPhoto/cache/lock.py
+++ b/src/iPhoto/cache/lock.py
@@ -1,0 +1,61 @@
+"""Simple file-based locking utilities."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Iterator
+
+from ..config import LOCK_EXPIRE_SEC, WORK_DIR_NAME
+from ..errors import LockTimeoutError
+
+
+class FileLock:
+    """A cooperative lock implemented using ``.lock`` files."""
+
+    def __init__(self, album_root: Path, name: str):
+        self.lock_path = album_root / WORK_DIR_NAME / "locks" / f"{name}.lock"
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def acquire(self, *, timeout: float = LOCK_EXPIRE_SEC) -> None:
+        deadline = time.monotonic() + timeout
+        info = {
+            "pid": os.getpid(),
+            "time": time.time(),
+            "host": os.uname().nodename if hasattr(os, "uname") else "unknown",
+        }
+        payload = json.dumps(info)
+        while True:
+            try:
+                fd = os.open(self.lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                try:
+                    os.write(fd, payload.encode("utf-8"))
+                finally:
+                    os.close(fd)
+                return
+            except FileExistsError:
+                if time.monotonic() > deadline:
+                    raise LockTimeoutError(f"Timed out acquiring lock {self.lock_path}")
+                # Check expiry
+                try:
+                    stat = self.lock_path.stat()
+                    if time.time() - stat.st_mtime > LOCK_EXPIRE_SEC:
+                        self.lock_path.unlink(missing_ok=True)
+                except FileNotFoundError:
+                    pass
+                time.sleep(0.1)
+
+    def release(self) -> None:
+        try:
+            self.lock_path.unlink()
+        except FileNotFoundError:
+            pass
+
+    def __enter__(self) -> "FileLock":
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.release()

--- a/src/iPhoto/cli.py
+++ b/src/iPhoto/cli.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 from pathlib import Path
+import sys
 
 import typer
 from rich import print
 
-from . import app as app_facade
+if __package__ in (None, ""):
+    package_root = Path(__file__).resolve().parent.parent
+    if str(package_root) not in sys.path:
+        sys.path.insert(0, str(package_root))
+    from iPhoto import app as app_facade  # type: ignore  # pragma: no cover
+else:
+    from . import app as app_facade
 from .cache.index_store import IndexStore
 from .config import WORK_DIR_NAME
 from .errors import AlbumNotFoundError, IPhotoError, LockTimeoutError, ManifestInvalidError

--- a/src/iPhoto/cli.py
+++ b/src/iPhoto/cli.py
@@ -1,0 +1,123 @@
+"""Typer-based CLI entry point."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich import print
+
+from . import app as app_facade
+from .cache.index_store import IndexStore
+from .config import WORK_DIR_NAME
+from .errors import AlbumNotFoundError, IPhotoError, LockTimeoutError, ManifestInvalidError
+from .models.album import Album
+
+app = typer.Typer(help="Folder-native photo manager with Live Photo support")
+cover_app = typer.Typer(help="Manage album covers")
+feature_app = typer.Typer(help="Manage featured assets")
+app.add_typer(cover_app, name="cover")
+app.add_typer(feature_app, name="feature")
+
+
+def _handle_errors(func):
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except (AlbumNotFoundError, ManifestInvalidError, LockTimeoutError) as exc:
+            typer.echo(f"Error: {exc}", err=True)
+            raise typer.Exit(1) from exc
+        except IPhotoError as exc:
+            typer.echo(f"Unexpected error: {exc}", err=True)
+            raise typer.Exit(1) from exc
+
+    return wrapper
+
+
+@app.command()
+@_handle_errors
+def init(album_dir: Path = typer.Argument(Path.cwd(), exists=False)) -> None:
+    """Initialise an album manifest if it does not exist."""
+
+    album_dir.mkdir(parents=True, exist_ok=True)
+    album = Album.open(album_dir)
+    album.save()
+    print(f"[green]Initialised album at {album_dir}")
+
+
+@app.command()
+@_handle_errors
+def scan(album_dir: Path = typer.Argument(Path.cwd(), exists=True)) -> None:
+    """Scan files and update the index cache."""
+
+    rows = app_facade.rescan(album_dir)
+    print(f"[green]Indexed {len(rows)} assets")
+
+
+@app.command()
+@_handle_errors
+def pair(album_dir: Path = typer.Argument(Path.cwd(), exists=True)) -> None:
+    """Rebuild Live Photo pairings."""
+
+    groups = app_facade.pair(album_dir)
+    print(f"[green]Paired {len(groups)} Live Photos")
+
+
+@cover_app.command("set")
+@_handle_errors
+def cover_set(album_dir: Path, rel: str) -> None:
+    """Set the album cover to the provided relative path."""
+
+    album = app_facade.open_album(album_dir)
+    album.set_cover(rel)
+    album.save()
+    print(f"[green]Set cover to {rel}")
+
+
+@feature_app.command("add")
+@_handle_errors
+def feature_add(album_dir: Path, ref: str) -> None:
+    """Add an item to the featured list."""
+
+    album = app_facade.open_album(album_dir)
+    album.add_featured(ref)
+    album.save()
+    print(f"[green]Added featured {ref}")
+
+
+@feature_app.command("rm")
+@_handle_errors
+def feature_rm(album_dir: Path, ref: str) -> None:
+    """Remove an item from the featured list."""
+
+    album = app_facade.open_album(album_dir)
+    album.remove_featured(ref)
+    album.save()
+    print(f"[green]Removed featured {ref}")
+
+
+@app.command()
+@_handle_errors
+def report(album_dir: Path = typer.Argument(Path.cwd(), exists=True)) -> None:
+    """Print a simple album report."""
+
+    album = app_facade.open_album(album_dir)
+    rows = list(IndexStore(album_dir).read_all())
+    work_dir = album_dir / WORK_DIR_NAME
+    links_path = work_dir / "links.json"
+    if links_path.exists():
+        import json
+
+        with links_path.open("r", encoding="utf-8") as handle:
+            groups = json.load(handle).get("live_groups", [])
+    else:
+        groups = [group.__dict__ for group in app_facade.pair(album_dir)]
+    print(
+        f"Album: {album.manifest.get('title')}\n"
+        f"Assets: {len(rows)}\n"
+        f"Live pairs: {len(groups)}"
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/src/iPhoto/cli.py
+++ b/src/iPhoto/cli.py
@@ -13,12 +13,21 @@ if __package__ in (None, ""):
     if str(package_root) not in sys.path:
         sys.path.insert(0, str(package_root))
     from iPhoto import app as app_facade  # type: ignore  # pragma: no cover
+    from iPhoto.cache.index_store import IndexStore  # type: ignore  # pragma: no cover
+    from iPhoto.config import WORK_DIR_NAME  # type: ignore  # pragma: no cover
+    from iPhoto.errors import (
+        AlbumNotFoundError,
+        IPhotoError,
+        LockTimeoutError,
+        ManifestInvalidError,
+    )  # type: ignore  # pragma: no cover
+    from iPhoto.models.album import Album  # type: ignore  # pragma: no cover
 else:
     from . import app as app_facade
-from .cache.index_store import IndexStore
-from .config import WORK_DIR_NAME
-from .errors import AlbumNotFoundError, IPhotoError, LockTimeoutError, ManifestInvalidError
-from .models.album import Album
+    from .cache.index_store import IndexStore
+    from .config import WORK_DIR_NAME
+    from .errors import AlbumNotFoundError, IPhotoError, LockTimeoutError, ManifestInvalidError
+    from .models.album import Album
 
 app = typer.Typer(help="Folder-native photo manager with Live Photo support")
 cover_app = typer.Typer(help="Manage album covers")

--- a/src/iPhoto/config.py
+++ b/src/iPhoto/config.py
@@ -1,0 +1,17 @@
+"""Default configuration values for iPhoto."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+
+DEFAULT_INCLUDE: Final[list[str]] = ["**/*.{HEIC,JPG,JPEG,PNG,MOV,MP4}"]
+DEFAULT_EXCLUDE: Final[list[str]] = ["**/.iPhoto/**", "**/.DS_Store", "**/._*"]
+PAIR_TIME_DELTA_SEC: Final[float] = 3.0
+LIVE_DURATION_PREFERRED: Final[tuple[float, float]] = (1.0, 3.5)
+LOCK_EXPIRE_SEC: Final[int] = 30
+THUMB_SIZES: Final[list[tuple[int, int]]] = [(256, 256), (512, 512)]
+
+SCHEMA_DIR: Final[Path] = Path(__file__).resolve().parent / "schemas"
+ALBUM_MANIFEST_NAMES: Final[list[str]] = [".iphoto.album.json", ".iPhoto/manifest.json"]
+WORK_DIR_NAME: Final[str] = ".iPhoto"

--- a/src/iPhoto/core/pairing.py
+++ b/src/iPhoto/core/pairing.py
@@ -1,0 +1,147 @@
+"""Live Photo pairing logic."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+from dateutil import parser
+
+from ..config import LIVE_DURATION_PREFERRED, PAIR_TIME_DELTA_SEC
+from ..models.types import LiveGroup
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return parser.isoparse(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def pair_live(index_rows: List[Dict[str, object]]) -> List[LiveGroup]:
+    """Pair still and motion assets into :class:`LiveGroup` objects."""
+
+    photos: Dict[str, Dict[str, object]] = {}
+    videos: Dict[str, Dict[str, object]] = {}
+    for row in index_rows:
+        mime = (row.get("mime") or "").lower()
+        if mime.startswith("image/"):
+            photos[row["rel"]] = row
+        elif mime.startswith("video/"):
+            videos[row["rel"]] = row
+
+    matched: Dict[str, LiveGroup] = {}
+    used_videos: set[str] = set()
+
+    # 1) strong match by content_id
+    video_by_cid: Dict[str, List[Dict[str, object]]] = defaultdict(list)
+    for video in videos.values():
+        cid = video.get("content_id")
+        if cid:
+            video_by_cid[cid].append(video)
+    for photo in photos.values():
+        cid = photo.get("content_id")
+        if not cid or cid not in video_by_cid:
+            continue
+        chosen = _select_best_video(video_by_cid[cid])
+        if chosen:
+            matched[photo["rel"]] = LiveGroup(
+                id=f"live_{hash((photo['rel'], chosen['rel'])) & 0xFFFFFF:x}",
+                still=photo["rel"],
+                motion=chosen["rel"],
+                content_id=cid,
+                still_image_time=chosen.get("still_image_time"),
+                confidence=1.0,
+            )
+            used_videos.add(chosen["rel"])
+
+    # 2) medium match by same stem + time delta
+    for photo in photos.values():
+        if photo["rel"] in matched:
+            continue
+        stem = Path(photo["rel"]).stem
+        candidates = [v for v in videos.values() if Path(v["rel"]).stem == stem]
+        chosen = _match_by_time(photo, candidates, used_videos)
+        if chosen:
+            used_videos.add(chosen["rel"])
+            matched[photo["rel"]] = _build_group(photo, chosen, confidence=0.7)
+
+    # 3) weak match by directory proximity
+    for photo in photos.values():
+        if photo["rel"] in matched:
+            continue
+        folder = str(Path(photo["rel"]).parent)
+        candidates = [v for v in videos.values() if str(Path(v["rel"]).parent) == folder]
+        chosen = _match_by_time(photo, candidates, used_videos)
+        if chosen:
+            used_videos.add(chosen["rel"])
+            matched[photo["rel"]] = _build_group(photo, chosen, confidence=0.5)
+
+    return list(matched.values())
+
+
+def _match_by_time(
+    photo: Dict[str, object],
+    candidates: Iterable[Dict[str, object]],
+    used_videos: set[str],
+) -> Dict[str, object] | None:
+    photo_dt = _parse_dt(photo.get("dt"))
+    best: Tuple[float, Dict[str, object]] | None = None
+    for candidate in candidates:
+        if candidate["rel"] in used_videos:
+            continue
+        video_dt = _parse_dt(candidate.get("dt"))
+        if not photo_dt or not video_dt:
+            continue
+        delta = abs((photo_dt - video_dt).total_seconds())
+        if delta > PAIR_TIME_DELTA_SEC:
+            continue
+        if best is None or delta < best[0]:
+            best = (delta, candidate)
+    return best[1] if best else None
+
+
+def _select_best_video(candidates: Iterable[Dict[str, object]]) -> Dict[str, object] | None:
+    best: Dict[str, object] | None = None
+    preferred_min, preferred_max = LIVE_DURATION_PREFERRED
+    for candidate in candidates:
+        dur = candidate.get("dur")
+        still_time = candidate.get("still_image_time")
+        if best is None:
+            best = candidate
+            continue
+        best_dur = best.get("dur")
+        if dur is not None and best_dur is not None:
+            current_score = _duration_score(dur, preferred_min, preferred_max)
+            best_score = _duration_score(best_dur, preferred_min, preferred_max)
+            if current_score > best_score:
+                best = candidate
+                continue
+        if still_time is not None and best.get("still_image_time") is not None:
+            if still_time < best["still_image_time"]:
+                best = candidate
+    return best
+
+
+def _duration_score(duration: float, preferred_min: float, preferred_max: float) -> float:
+    if duration < preferred_min:
+        return -preferred_min + duration
+    if duration > preferred_max:
+        return -duration
+    midpoint = (preferred_min + preferred_max) / 2
+    return preferred_max - abs(midpoint - duration)
+
+
+def _build_group(photo: Dict[str, object], video: Dict[str, object], confidence: float) -> LiveGroup:
+    return LiveGroup(
+        id=f"live_{hash((photo['rel'], video['rel'])) & 0xFFFFFF:x}",
+        still=photo["rel"],
+        motion=video["rel"],
+        content_id=video.get("content_id") or photo.get("content_id"),
+        still_image_time=video.get("still_image_time"),
+        confidence=confidence,
+    )

--- a/src/iPhoto/errors.py
+++ b/src/iPhoto/errors.py
@@ -1,0 +1,31 @@
+"""Custom exception hierarchy for iPhoto."""
+
+from __future__ import annotations
+
+
+class IPhotoError(Exception):
+    """Base class for all custom errors raised by iPhoto."""
+
+
+class AlbumNotFoundError(IPhotoError):
+    """Raised when the requested album cannot be located."""
+
+
+class ManifestInvalidError(IPhotoError):
+    """Raised when a manifest fails validation against the schema."""
+
+
+class ExternalToolError(IPhotoError):
+    """Raised when an external tool such as exiftool or ffmpeg fails."""
+
+
+class IndexCorruptedError(IPhotoError):
+    """Raised when the cached index cannot be parsed."""
+
+
+class PairingConflictError(IPhotoError):
+    """Raised when mutually exclusive Live Photo pairings are detected."""
+
+
+class LockTimeoutError(IPhotoError):
+    """Raised when a file-level lock cannot be acquired in time."""

--- a/src/iPhoto/gui/__init__.py
+++ b/src/iPhoto/gui/__init__.py
@@ -1,0 +1,7 @@
+"""GUI package for the iPhoto application."""
+
+from .facade import AppFacade
+from .main import main
+from .ui.main_window import MainWindow
+
+__all__ = ["AppFacade", "MainWindow", "main"]

--- a/src/iPhoto/gui/facade.py
+++ b/src/iPhoto/gui/facade.py
@@ -1,0 +1,125 @@
+"""Qt-aware facade that bridges the CLI backend to the GUI layer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+from PySide6.QtCore import QObject, Signal
+
+from .. import app as backend
+from ..errors import IPhotoError
+from ..models.album import Album
+
+
+class AppFacade(QObject):
+    """Expose high-level album operations to the GUI layer."""
+
+    albumOpened = Signal(object)
+    indexUpdated = Signal(object)
+    linksUpdated = Signal(object)
+    errorRaised = Signal(str)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._current_album: Optional[Album] = None
+
+    # ------------------------------------------------------------------
+    # Album lifecycle
+    # ------------------------------------------------------------------
+    @property
+    def current_album(self) -> Optional[Album]:
+        """Return the album currently loaded in the facade."""
+
+        return self._current_album
+
+    def open_album(self, root: Path) -> Optional[Album]:
+        """Open *root* and emit signals for the loaded data."""
+
+        try:
+            album = backend.open_album(root)
+        except IPhotoError as exc:
+            self.errorRaised.emit(str(exc))
+            return None
+        self._current_album = album
+        self.albumOpened.emit(album.root)
+        self.indexUpdated.emit(album.root)
+        self.linksUpdated.emit(album.root)
+        return album
+
+    def rescan_current(self) -> List[dict]:
+        """Rescan the active album and emit ``indexUpdated`` when done."""
+
+        album = self._require_album()
+        if album is None:
+            return []
+        try:
+            rows = backend.rescan(album.root)
+        except IPhotoError as exc:
+            self.errorRaised.emit(str(exc))
+            return []
+        self.indexUpdated.emit(album.root)
+        return rows
+
+    def pair_live_current(self) -> List[dict]:
+        """Rebuild Live Photo pairings for the active album."""
+
+        album = self._require_album()
+        if album is None:
+            return []
+        try:
+            groups = backend.pair(album.root)
+        except IPhotoError as exc:
+            self.errorRaised.emit(str(exc))
+            return []
+        self.linksUpdated.emit(album.root)
+        return [group.__dict__ for group in groups]
+
+    # ------------------------------------------------------------------
+    # Manifest helpers
+    # ------------------------------------------------------------------
+    def set_cover(self, rel: str) -> bool:
+        """Set the album cover to *rel* and persist the manifest."""
+
+        album = self._require_album()
+        if album is None:
+            return False
+        album.set_cover(rel)
+        return self._save_manifest(album)
+
+    def toggle_featured(self, ref: str) -> bool:
+        """Toggle *ref* in the album's featured list."""
+
+        album = self._require_album()
+        if album is None:
+            return False
+        featured = album.manifest.setdefault("featured", [])
+        if ref in featured:
+            album.remove_featured(ref)
+            changed = False
+        else:
+            album.add_featured(ref)
+            changed = True
+        if self._save_manifest(album):
+            return changed
+        return False
+
+    # ------------------------------------------------------------------
+    # Internal utilities
+    # ------------------------------------------------------------------
+    def _save_manifest(self, album: Album) -> bool:
+        try:
+            album.save()
+        except IPhotoError as exc:
+            self.errorRaised.emit(str(exc))
+            return False
+        # Reload to ensure any concurrent edits are picked up.
+        self._current_album = Album.open(album.root)
+        self.albumOpened.emit(album.root)
+        return True
+
+    def _require_album(self) -> Optional[Album]:
+        if self._current_album is None:
+            self.errorRaised.emit("No album is currently open.")
+            return None
+        return self._current_album

--- a/src/iPhoto/gui/main.py
+++ b/src/iPhoto/gui/main.py
@@ -11,8 +11,8 @@ if __package__ is None or __package__ == "":  # pragma: no cover - script mode
     package_root = Path(__file__).resolve().parents[2]
     if str(package_root) not in sys.path:
         sys.path.insert(0, str(package_root))
-    from iPhoto.appctx import AppContext
-    from iPhoto.gui.ui.main_window import MainWindow
+    from iPhotos.src.iPhoto.appctx import AppContext
+    from iPhotos.src.iPhoto.gui.ui.main_window import MainWindow
 else:  # pragma: no cover - normal package execution
     from ..appctx import AppContext
     from .ui.main_window import MainWindow

--- a/src/iPhoto/gui/main.py
+++ b/src/iPhoto/gui/main.py
@@ -1,0 +1,29 @@
+"""GUI entry point for the iPhoto desktop application."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from PySide6.QtWidgets import QApplication
+
+from ..appctx import AppContext
+from .ui.main_window import MainWindow
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Launch the Qt application and return the exit code."""
+
+    arguments = list(sys.argv if argv is None else argv)
+    app = QApplication(arguments)
+    context = AppContext()
+    window = MainWindow(context)
+    window.show()
+    # Allow opening an album directly via argv[1].
+    if len(arguments) > 1:
+        window.open_album_from_path(Path(arguments[1]))
+    return app.exec()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    raise SystemExit(main())

--- a/src/iPhoto/gui/main.py
+++ b/src/iPhoto/gui/main.py
@@ -7,8 +7,15 @@ from pathlib import Path
 
 from PySide6.QtWidgets import QApplication
 
-from ..appctx import AppContext
-from .ui.main_window import MainWindow
+if __package__ is None or __package__ == "":  # pragma: no cover - script mode
+    package_root = Path(__file__).resolve().parents[2]
+    if str(package_root) not in sys.path:
+        sys.path.insert(0, str(package_root))
+    from iPhoto.appctx import AppContext
+    from iPhoto.gui.ui.main_window import MainWindow
+else:  # pragma: no cover - normal package execution
+    from ..appctx import AppContext
+    from .ui.main_window import MainWindow
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/iPhoto/gui/ui/__init__.py
+++ b/src/iPhoto/gui/ui/__init__.py
@@ -1,0 +1,5 @@
+"""Qt widget package for the iPhoto GUI."""
+
+from .main_window import MainWindow
+
+__all__ = ["MainWindow"]

--- a/src/iPhoto/gui/ui/main_window.py
+++ b/src/iPhoto/gui/ui/main_window.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from PySide6.QtCore import QSize
 from PySide6.QtWidgets import (
     QFileDialog,
     QLabel,
@@ -60,10 +61,15 @@ class MainWindow(QMainWindow):
 
         self._list_view.setModel(self._asset_model)
         self._list_view.setSelectionMode(QListView.ExtendedSelection)
-        self._list_view.setAlternatingRowColors(True)
+        self._list_view.setViewMode(QListView.IconMode)
+        self._list_view.setIconSize(QSize(192, 192))
+        self._list_view.setGridSize(QSize(216, 248))
+        self._list_view.setSpacing(12)
         self._list_view.setUniformItemSizes(True)
         self._list_view.setResizeMode(QListView.Adjust)
-        self._list_view.setViewMode(QListView.ListMode)
+        self._list_view.setMovement(QListView.Static)
+        self._list_view.setWrapping(True)
+        self._list_view.setWordWrap(True)
         self._list_view.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         layout.addWidget(self._list_view, stretch=1)
 

--- a/src/iPhoto/gui/ui/main_window.py
+++ b/src/iPhoto/gui/ui/main_window.py
@@ -1,0 +1,126 @@
+"""Qt widgets composing the main application window."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtWidgets import (
+    QFileDialog,
+    QLabel,
+    QListView,
+    QMainWindow,
+    QMessageBox,
+    QSizePolicy,
+    QStatusBar,
+    QToolBar,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ...appctx import AppContext
+from ..facade import AppFacade
+from .models.asset_model import AssetModel, Roles
+
+
+class MainWindow(QMainWindow):
+    """Primary window for the desktop experience."""
+
+    def __init__(self, context: AppContext) -> None:
+        super().__init__()
+        self._context = context
+        self._facade: AppFacade = context.facade
+        self._asset_model = AssetModel(self._facade)
+        self._album_label = QLabel("Open a folder to browse your photos.")
+        self._list_view = QListView()
+        self._status = QStatusBar()
+        self.setWindowTitle("iPhoto")
+        self.resize(1200, 720)
+        self._build_ui()
+        self._connect_signals()
+
+    # ------------------------------------------------------------------
+    # UI setup
+    # ------------------------------------------------------------------
+    def _build_ui(self) -> None:
+        toolbar = QToolBar("Main")
+        toolbar.setMovable(False)
+        open_action = toolbar.addAction("Open Album…")
+        open_action.triggered.connect(lambda _: self._show_open_dialog())
+        rescan_action = toolbar.addAction("Rescan")
+        rescan_action.triggered.connect(lambda _: self._facade.rescan_current())
+        pair_action = toolbar.addAction("Rebuild Live Links")
+        pair_action.triggered.connect(lambda _: self._facade.pair_live_current())
+        self.addToolBar(toolbar)
+
+        container = QWidget()
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(12, 12, 12, 12)
+        self._album_label.setObjectName("albumLabel")
+        layout.addWidget(self._album_label)
+
+        self._list_view.setModel(self._asset_model)
+        self._list_view.setSelectionMode(QListView.ExtendedSelection)
+        self._list_view.setAlternatingRowColors(True)
+        self._list_view.setUniformItemSizes(True)
+        self._list_view.setResizeMode(QListView.Adjust)
+        self._list_view.setViewMode(QListView.ListMode)
+        self._list_view.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        layout.addWidget(self._list_view, stretch=1)
+
+        self.setCentralWidget(container)
+        self.setStatusBar(self._status)
+        self._status.showMessage("Ready")
+
+    def _connect_signals(self) -> None:
+        self._facade.errorRaised.connect(self._show_error)
+        self._facade.albumOpened.connect(self._on_album_opened)
+        self._asset_model.modelReset.connect(self._update_status)
+        self._asset_model.rowsInserted.connect(self._update_status)
+        self._asset_model.rowsRemoved.connect(self._update_status)
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+    def _show_open_dialog(self) -> None:
+        path = QFileDialog.getExistingDirectory(self, "Select album")
+        if path:
+            self.open_album_from_path(Path(path))
+
+    def open_album_from_path(self, path: Path) -> None:
+        """Open *path* as the active album."""
+
+        album = self._facade.open_album(path)
+        if album is not None:
+            self._context.remember_album(album.root)
+
+    def _show_error(self, message: str) -> None:
+        QMessageBox.critical(self, "iPhoto", message)
+
+    def _on_album_opened(self, root: Path) -> None:
+        title = self._facade.current_album.manifest.get("title") if self._facade.current_album else root.name
+        self._album_label.setText(f"{title} — {root}")
+        self._update_status()
+
+    def _update_status(self) -> None:
+        count = self._asset_model.rowCount()
+        if count == 0:
+            message = "No assets indexed"
+        elif count == 1:
+            message = "1 asset indexed"
+        else:
+            message = f"{count} assets indexed"
+        self._status.showMessage(message)
+
+    # ------------------------------------------------------------------
+    # Convenience
+    # ------------------------------------------------------------------
+    def current_selection(self) -> list[Path]:
+        """Return the currently selected assets as absolute paths."""
+
+        indexes = self._list_view.selectionModel().selectedIndexes()
+        paths: list[Path] = []
+        for index in indexes:
+            rel = self._asset_model.data(index, Roles.REL)
+            if rel and self._facade.current_album:
+                paths.append((self._facade.current_album.root / rel).resolve())
+        return paths

--- a/src/iPhoto/gui/ui/main_window.py
+++ b/src/iPhoto/gui/ui/main_window.py
@@ -21,6 +21,7 @@ from PySide6.QtWidgets import (
 from ...appctx import AppContext
 from ..facade import AppFacade
 from .models.asset_model import AssetModel, Roles
+from .widgets.asset_delegate import AssetGridDelegate
 
 
 class MainWindow(QMainWindow):
@@ -55,21 +56,25 @@ class MainWindow(QMainWindow):
 
         container = QWidget()
         layout = QVBoxLayout(container)
-        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setContentsMargins(8, 8, 8, 8)
         self._album_label.setObjectName("albumLabel")
         layout.addWidget(self._album_label)
 
         self._list_view.setModel(self._asset_model)
+        self._list_view.setItemDelegate(AssetGridDelegate(self._list_view))
         self._list_view.setSelectionMode(QListView.ExtendedSelection)
         self._list_view.setViewMode(QListView.IconMode)
         self._list_view.setIconSize(QSize(192, 192))
-        self._list_view.setGridSize(QSize(216, 248))
-        self._list_view.setSpacing(12)
+        self._list_view.setGridSize(QSize(194, 194))
+        self._list_view.setSpacing(2)
         self._list_view.setUniformItemSizes(True)
         self._list_view.setResizeMode(QListView.Adjust)
         self._list_view.setMovement(QListView.Static)
         self._list_view.setWrapping(True)
-        self._list_view.setWordWrap(True)
+        self._list_view.setWordWrap(False)
+        self._list_view.setStyleSheet(
+            "QListView::item { margin: 0px; padding: 0px; }"
+        )
         self._list_view.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         layout.addWidget(self._list_view, stretch=1)
 

--- a/src/iPhoto/gui/ui/models/__init__.py
+++ b/src/iPhoto/gui/ui/models/__init__.py
@@ -1,0 +1,5 @@
+"""Expose Qt models used by the GUI."""
+
+from .asset_model import AssetModel, Roles
+
+__all__ = ["AssetModel", "Roles"]

--- a/src/iPhoto/gui/ui/models/asset_model.py
+++ b/src/iPhoto/gui/ui/models/asset_model.py
@@ -111,13 +111,18 @@ class _ThumbnailJob(QRunnable):
 
     def _composite_canvas(self, image: QImage) -> QImage:  # pragma: no cover - worker helper
         canvas = QImage(self._size, QImage.Format_ARGB32)
-        canvas.fill(QColor("#2d2d2d"))
-        scaled = image.scaled(self._size, Qt.KeepAspectRatio, Qt.SmoothTransformation)
+        canvas.fill(QColor("#1b1b1b"))
+        scaled = image.scaled(
+            self._size,
+            Qt.KeepAspectRatioByExpanding,
+            Qt.SmoothTransformation,
+        )
         painter = QPainter(canvas)
         painter.setRenderHint(QPainter.Antialiasing)
-        x = (canvas.width() - scaled.width()) // 2
-        y = (canvas.height() - scaled.height()) // 2
-        painter.drawImage(x, y, scaled)
+        target_rect = canvas.rect()
+        source_rect = scaled.rect()
+        source_rect.moveCenter(target_rect.center())
+        painter.drawImage(target_rect, scaled, source_rect)
         painter.end()
         return canvas
 
@@ -282,11 +287,11 @@ class AssetModel(QAbstractListModel):
             return None
         row = self._rows[index.row()]
         if role == Qt.DisplayRole:
-            return row["name"]
+            return ""
         if role == Qt.DecorationRole:
             return self._resolve_thumbnail(row)
         if role == Qt.SizeHintRole:
-            return QSize(self._thumb_size.width() + 24, self._thumb_size.height() + 48)
+            return QSize(self._thumb_size.width(), self._thumb_size.height())
         if role == Roles.REL:
             return row["rel"]
         if role == Roles.ABS:
@@ -457,7 +462,7 @@ class AssetModel(QAbstractListModel):
         if cached is not None:
             return cached
         canvas = QPixmap(self._thumb_size)
-        canvas.fill(QColor("#2d2d2d"))
+        canvas.fill(QColor("#1b1b1b"))
         painter = QPainter(canvas)
         painter.setRenderHint(QPainter.Antialiasing)
         painter.setPen(QColor("#f0f0f0"))

--- a/src/iPhoto/gui/ui/models/asset_model.py
+++ b/src/iPhoto/gui/ui/models/asset_model.py
@@ -21,20 +21,7 @@ from PySide6.QtCore import (
 from PySide6.QtGui import QColor, QFont, QFontMetrics, QImage, QImageReader, QPainter, QPixmap
 from shiboken6 import Shiboken
 
-try:  # pragma: no cover - optional dependency
-    from PIL import Image, ImageOps
-    from PIL.ImageQt import ImageQt
-except Exception:  # pragma: no cover - pillow not available or broken
-    Image = None  # type: ignore[assignment]
-    ImageOps = None  # type: ignore[assignment]
-    ImageQt = None  # type: ignore[assignment]
-else:  # pragma: no cover - executed when pillow is present
-    try:
-        import pillow_heif
-    except Exception:  # pragma: no cover - pillow-heif optional
-        pillow_heif = None  # type: ignore[assignment]
-    else:
-        pillow_heif.register_heif_opener()
+from ....utils.deps import load_pillow
 
 from ....cache.index_store import IndexStore
 from ....config import WORK_DIR_NAME
@@ -43,6 +30,17 @@ from ....utils.ffmpeg import extract_video_frame
 from ....utils.jsonio import read_json
 from ....utils.pathutils import ensure_work_dir
 from ...facade import AppFacade
+
+_PILLOW = load_pillow()
+
+if _PILLOW is not None:
+    Image = _PILLOW.Image
+    ImageOps = _PILLOW.ImageOps
+    ImageQt = _PILLOW.ImageQt
+else:  # pragma: no cover - executed when Pillow is missing
+    Image = None  # type: ignore[assignment]
+    ImageOps = None  # type: ignore[assignment]
+    ImageQt = None  # type: ignore[assignment]
 
 
 class _ThumbnailJob(QRunnable):

--- a/src/iPhoto/gui/ui/models/asset_model.py
+++ b/src/iPhoto/gui/ui/models/asset_model.py
@@ -1,0 +1,184 @@
+"""Qt model that exposes album assets to views."""
+
+from __future__ import annotations
+
+from enum import IntEnum
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from PySide6.QtCore import QAbstractListModel, QModelIndex, Qt
+
+from ....cache.index_store import IndexStore
+from ....config import WORK_DIR_NAME
+from ....utils.jsonio import read_json
+from ....utils.pathutils import ensure_work_dir
+from ...facade import AppFacade
+
+
+class Roles(IntEnum):
+    """Custom roles exposed to QML or widgets."""
+
+    REL = Qt.UserRole + 1
+    ABS = Qt.UserRole + 2
+    ASSET_ID = Qt.UserRole + 3
+    IS_IMAGE = Qt.UserRole + 4
+    IS_VIDEO = Qt.UserRole + 5
+    IS_LIVE = Qt.UserRole + 6
+    LIVE_GROUP_ID = Qt.UserRole + 7
+    SIZE = Qt.UserRole + 8
+    DT = Qt.UserRole + 9
+    FEATURED = Qt.UserRole + 10
+
+
+class AssetModel(QAbstractListModel):
+    """List model combining ``index.jsonl`` and ``links.json`` data."""
+
+    def __init__(self, facade: AppFacade) -> None:
+        super().__init__()
+        self._facade = facade
+        self._album_root: Optional[Path] = None
+        self._rows: List[Dict[str, object]] = []
+        facade.albumOpened.connect(self._on_album_opened)
+        facade.indexUpdated.connect(self._on_index_updated)
+        facade.linksUpdated.connect(self._on_links_updated)
+
+    # ------------------------------------------------------------------
+    # Qt model implementation
+    # ------------------------------------------------------------------
+    def rowCount(self, parent: QModelIndex | None = None) -> int:  # type: ignore[override]
+        if parent is not None and parent.isValid():  # pragma: no cover - tree fallback
+            return 0
+        return len(self._rows)
+
+    def data(self, index: QModelIndex, role: int = Qt.DisplayRole):  # type: ignore[override]
+        if not index.isValid() or not (0 <= index.row() < len(self._rows)):
+            return None
+        row = self._rows[index.row()]
+        if role == Qt.DisplayRole:
+            return row["name"]
+        if role == Roles.REL:
+            return row["rel"]
+        if role == Roles.ABS:
+            return row["abs"]
+        if role == Roles.ASSET_ID:
+            return row["id"]
+        if role == Roles.IS_IMAGE:
+            return row["is_image"]
+        if role == Roles.IS_VIDEO:
+            return row["is_video"]
+        if role == Roles.IS_LIVE:
+            return row["is_live"]
+        if role == Roles.LIVE_GROUP_ID:
+            return row["live_group_id"]
+        if role == Roles.SIZE:
+            return row["size"]
+        if role == Roles.DT:
+            return row["dt"]
+        if role == Roles.FEATURED:
+            return row["featured"]
+        return None
+
+    def roleNames(self) -> Dict[int, bytes]:  # type: ignore[override]
+        names = super().roleNames()
+        names.update(
+            {
+                Roles.REL: b"rel",
+                Roles.ABS: b"abs",
+                Roles.ASSET_ID: b"assetId",
+                Roles.IS_IMAGE: b"isImage",
+                Roles.IS_VIDEO: b"isVideo",
+                Roles.IS_LIVE: b"isLive",
+                Roles.LIVE_GROUP_ID: b"liveGroupId",
+                Roles.SIZE: b"size",
+                Roles.DT: b"dt",
+                Roles.FEATURED: b"featured",
+            }
+        )
+        return names
+
+    # ------------------------------------------------------------------
+    # Facade callbacks
+    # ------------------------------------------------------------------
+    def _on_album_opened(self, root: Path) -> None:
+        self._album_root = root
+        self._reload()
+
+    def _on_index_updated(self, root: Path) -> None:
+        if self._album_root and root == self._album_root:
+            self._reload()
+
+    def _on_links_updated(self, root: Path) -> None:
+        if self._album_root and root == self._album_root:
+            self._reload()
+
+    # ------------------------------------------------------------------
+    # Data loading helpers
+    # ------------------------------------------------------------------
+    def _reload(self) -> None:
+        if not self._album_root:
+            return
+        ensure_work_dir(self._album_root, WORK_DIR_NAME)
+        manifest = self._facade.current_album.manifest if self._facade.current_album else {}
+        featured: set[str] = set(manifest.get("featured", []))
+        index_rows = list(IndexStore(self._album_root).read_all())
+        live_map = self._load_live_map(self._album_root)
+
+        payload: List[Dict[str, object]] = []
+        for row in index_rows:
+            rel = str(row["rel"])
+            abs_path = (self._album_root / rel).resolve().as_posix()
+            mime = (row.get("mime") or "").lower()
+            is_image = mime.startswith("image/")
+            is_video = mime.startswith("video/")
+            live_info = live_map.get(rel)
+            entry: Dict[str, object] = {
+                "rel": rel,
+                "abs": abs_path,
+                "id": row.get("id", rel),
+                "name": Path(rel).name,
+                "is_image": is_image,
+                "is_video": is_video,
+                "is_live": bool(live_info),
+                "live_group_id": live_info[0] if live_info else None,
+                "size": self._determine_size(row, is_image),
+                "dt": row.get("dt"),
+                "featured": self._is_featured(rel, featured),
+            }
+            payload.append(entry)
+
+        self.beginResetModel()
+        self._rows = payload
+        self.endResetModel()
+
+    @staticmethod
+    def _load_live_map(root: Path) -> Dict[str, tuple[str, str]]:
+        path = root / WORK_DIR_NAME / "links.json"
+        if not path.exists():
+            return {}
+        try:
+            data = read_json(path)
+        except Exception:  # pragma: no cover - invalid JSON handled softly
+            return {}
+        mapping: Dict[str, tuple[str, str]] = {}
+        for group in data.get("live_groups", []):
+            gid = group.get("id")
+            still = group.get("still")
+            motion = group.get("motion")
+            if gid and still:
+                mapping[str(still)] = (gid, "still")
+            if gid and motion:
+                mapping[str(motion)] = (gid, "motion")
+        return mapping
+
+    @staticmethod
+    def _determine_size(row: Dict[str, object], is_image: bool) -> object:
+        if is_image:
+            return (row.get("w"), row.get("h"))
+        return {"bytes": row.get("bytes"), "duration": row.get("dur")}
+
+    @staticmethod
+    def _is_featured(rel: str, featured: set[str]) -> bool:
+        if rel in featured:
+            return True
+        live_ref = f"{rel}#live"
+        return live_ref in featured

--- a/src/iPhoto/gui/ui/models/asset_model.py
+++ b/src/iPhoto/gui/ui/models/asset_model.py
@@ -110,8 +110,8 @@ class _ThumbnailJob(QRunnable):
             return None
 
     def _composite_canvas(self, image: QImage) -> QImage:  # pragma: no cover - worker helper
-        canvas = QImage(self._size, QImage.Format_ARGB32)
-        canvas.fill(QColor("#1b1b1b"))
+        canvas = QImage(self._size, QImage.Format_ARGB32_Premultiplied)
+        canvas.fill(Qt.transparent)
         scaled = image.scaled(
             self._size,
             Qt.KeepAspectRatioByExpanding,
@@ -121,7 +121,16 @@ class _ThumbnailJob(QRunnable):
         painter.setRenderHint(QPainter.Antialiasing)
         target_rect = canvas.rect()
         source_rect = scaled.rect()
-        source_rect.moveCenter(target_rect.center())
+        if source_rect.width() > target_rect.width():
+            diff = source_rect.width() - target_rect.width()
+            left = diff // 2
+            right = diff - left
+            source_rect.adjust(left, 0, -right, 0)
+        if source_rect.height() > target_rect.height():
+            diff = source_rect.height() - target_rect.height()
+            top = diff // 2
+            bottom = diff - top
+            source_rect.adjust(0, top, 0, -bottom)
         painter.drawImage(target_rect, scaled, source_rect)
         painter.end()
         return canvas

--- a/src/iPhoto/gui/ui/widgets/__init__.py
+++ b/src/iPhoto/gui/ui/widgets/__init__.py
@@ -1,0 +1,5 @@
+"""Reusable Qt widgets for the iPhoto GUI."""
+
+from .asset_delegate import AssetGridDelegate
+
+__all__ = ["AssetGridDelegate"]

--- a/src/iPhoto/gui/ui/widgets/asset_delegate.py
+++ b/src/iPhoto/gui/ui/widgets/asset_delegate.py
@@ -25,19 +25,23 @@ class AssetGridDelegate(QStyledItemDelegate):
         painter.save()
         rect = option.rect
         pixmap = index.data(Qt.DecorationRole)
-        painter.fillRect(rect, option.palette.color(QPalette.Base))
 
         if isinstance(pixmap, QPixmap) and not pixmap.isNull():
             painter.setRenderHint(QPainter.Antialiasing, True)
             painter.setRenderHint(QPainter.SmoothPixmapTransform, True)
-            painter.setClipRect(rect)
             scaled = pixmap.scaled(rect.size(), Qt.KeepAspectRatioByExpanding, Qt.SmoothTransformation)
-            top_left = QPoint(
-                rect.x() + (rect.width() - scaled.width()) // 2,
-                rect.y() + (rect.height() - scaled.height()) // 2,
-            )
-            painter.drawPixmap(top_left, scaled)
-            painter.setClipping(False)
+            source = scaled.rect()
+            if source.width() > rect.width():
+                diff = source.width() - rect.width()
+                left = diff // 2
+                right = diff - left
+                source.adjust(left, 0, -right, 0)
+            if source.height() > rect.height():
+                diff = source.height() - rect.height()
+                top = diff // 2
+                bottom = diff - top
+                source.adjust(0, top, 0, -bottom)
+            painter.drawPixmap(rect, scaled, source)
         else:
             painter.fillRect(rect, QColor("#1b1b1b"))
 

--- a/src/iPhoto/gui/ui/widgets/asset_delegate.py
+++ b/src/iPhoto/gui/ui/widgets/asset_delegate.py
@@ -47,6 +47,9 @@ class AssetGridDelegate(QStyledItemDelegate):
             overlay.setAlpha(110)
             painter.fillRect(rect, overlay)
 
+        if index.data(Roles.IS_LIVE):
+            self._draw_live_badge(painter, option, rect)
+
         if index.data(Roles.IS_VIDEO):
             self._draw_duration_badge(painter, option, rect, index.data(Roles.SIZE))
 
@@ -94,6 +97,31 @@ class AssetGridDelegate(QStyledItemDelegate):
         painter.setPen(QColor("white"))
         painter.setFont(font)
         painter.drawText(badge_rect, Qt.AlignCenter, text)
+        painter.restore()
+
+    def _draw_live_badge(
+        self,
+        painter: QPainter,
+        option: QStyleOptionViewItem,
+        rect: QRect,
+    ) -> None:
+        font = self._duration_font or QFont(option.font)
+        font.setPointSizeF(max(8.0, option.font.pointSizeF() - 2))
+        font.setBold(True)
+        metrics = QFontMetrics(font)
+        label = "LIVE"
+        padding = 5
+        height = metrics.height() + padding
+        width = metrics.horizontalAdvance(label) + padding * 2
+        badge_rect = QRect(rect.left() + 8, rect.top() + 8, width, height)
+        painter.save()
+        painter.setRenderHint(QPainter.Antialiasing, True)
+        painter.setPen(Qt.NoPen)
+        painter.setBrush(QColor(0, 0, 0, 140))
+        painter.drawRoundedRect(badge_rect, 6, 6)
+        painter.setPen(QColor("white"))
+        painter.setFont(font)
+        painter.drawText(badge_rect, Qt.AlignCenter, label)
         painter.restore()
 
     @staticmethod

--- a/src/iPhoto/gui/ui/widgets/asset_delegate.py
+++ b/src/iPhoto/gui/ui/widgets/asset_delegate.py
@@ -1,0 +1,106 @@
+"""Custom delegate for drawing album grid tiles."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from PySide6.QtCore import QPoint, QRect, Qt
+from PySide6.QtGui import QColor, QFont, QFontMetrics, QPainter, QPalette, QPixmap
+from PySide6.QtWidgets import QStyle, QStyleOptionViewItem, QStyledItemDelegate
+
+from ..models.asset_model import Roles
+
+
+class AssetGridDelegate(QStyledItemDelegate):
+    """Render thumbnails in a tight, borderless grid."""
+
+    def __init__(self, parent=None) -> None:  # type: ignore[override]
+        super().__init__(parent)
+        self._duration_font: Optional[QFont] = None
+
+    # ------------------------------------------------------------------
+    # Painting
+    # ------------------------------------------------------------------
+    def paint(self, painter: QPainter, option: QStyleOptionViewItem, index) -> None:  # type: ignore[override]
+        painter.save()
+        rect = option.rect
+        pixmap = index.data(Qt.DecorationRole)
+        painter.fillRect(rect, option.palette.color(QPalette.Base))
+
+        if isinstance(pixmap, QPixmap) and not pixmap.isNull():
+            painter.setRenderHint(QPainter.Antialiasing, True)
+            painter.setRenderHint(QPainter.SmoothPixmapTransform, True)
+            painter.setClipRect(rect)
+            scaled = pixmap.scaled(rect.size(), Qt.KeepAspectRatioByExpanding, Qt.SmoothTransformation)
+            top_left = QPoint(
+                rect.x() + (rect.width() - scaled.width()) // 2,
+                rect.y() + (rect.height() - scaled.height()) // 2,
+            )
+            painter.drawPixmap(top_left, scaled)
+            painter.setClipping(False)
+        else:
+            painter.fillRect(rect, QColor("#1b1b1b"))
+
+        if option.state & QStyle.State_Selected:
+            highlight = option.palette.color(QPalette.Highlight)
+            overlay = QColor(highlight)
+            overlay.setAlpha(110)
+            painter.fillRect(rect, overlay)
+
+        if index.data(Roles.IS_VIDEO):
+            self._draw_duration_badge(painter, option, rect, index.data(Roles.SIZE))
+
+        painter.restore()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _draw_duration_badge(
+        self,
+        painter: QPainter,
+        option: QStyleOptionViewItem,
+        rect: QRect,
+        size_info: object,
+    ) -> None:
+        duration = None
+        if isinstance(size_info, dict):
+            raw = size_info.get("duration")  # type: ignore[arg-type]
+            if isinstance(raw, (int, float)):
+                duration = max(0, float(raw))
+        if duration is None:
+            return
+        text = self._format_duration(duration)
+        if not text:
+            return
+        font = self._duration_font or QFont(option.font)
+        font.setPointSizeF(max(9.0, option.font.pointSizeF() - 1))
+        font.setBold(True)
+        self._duration_font = font
+        metrics = QFontMetrics(font)
+        padding = 6
+        height = metrics.height() + padding
+        width = metrics.horizontalAdvance(text) + padding * 2
+        badge_rect = QRect(
+            rect.right() - width - 8,
+            rect.bottom() - height - 8,
+            width,
+            height,
+        )
+        painter.save()
+        painter.setRenderHint(QPainter.Antialiasing, True)
+        painter.setPen(Qt.NoPen)
+        painter.setBrush(QColor(0, 0, 0, 160))
+        painter.drawRoundedRect(badge_rect, 6, 6)
+        painter.setPen(QColor("white"))
+        painter.setFont(font)
+        painter.drawText(badge_rect, Qt.AlignCenter, text)
+        painter.restore()
+
+    @staticmethod
+    def _format_duration(duration: float) -> str:
+        seconds = int(round(duration))
+        minutes, secs = divmod(seconds, 60)
+        hours, minutes = divmod(minutes, 60)
+        if hours:
+            return f"{hours:d}:{minutes:02d}:{secs:02d}"
+        return f"{minutes:d}:{secs:02d}"

--- a/src/iPhoto/io/metadata.py
+++ b/src/iPhoto/io/metadata.py
@@ -1,0 +1,63 @@
+"""Metadata readers for media assets."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+from PIL import Image, UnidentifiedImageError
+
+try:  # pragma: no cover - optional dependency registration
+    from pillow_heif import register_heif_opener
+except ImportError:  # pragma: no cover
+    register_heif_opener = None
+
+from ..errors import ExternalToolError
+
+if register_heif_opener is not None:  # pragma: no branch
+    register_heif_opener()
+
+
+def read_image_meta(path: Path) -> Dict[str, Any]:
+    """Read metadata for an image file using Pillow."""
+
+    try:
+        with Image.open(path) as img:
+            exif = img.getexif() if hasattr(img, "getexif") else None
+            info: Dict[str, Any] = {
+                "w": img.width,
+                "h": img.height,
+                "mime": Image.MIME.get(img.format, None),
+                "dt": None,
+                "make": None,
+                "model": None,
+                "gps": None,
+                "content_id": None,
+            }
+            if exif:
+                dt_value = exif.get(36867) or exif.get(306)
+                if isinstance(dt_value, str):
+                    try:
+                        captured = datetime.strptime(dt_value, "%Y:%m:%d %H:%M:%S")
+                        info["dt"] = captured.replace(tzinfo=timezone.utc).isoformat().replace(
+                            "+00:00", "Z"
+                        )
+                    except ValueError:
+                        info["dt"] = None
+            return info
+    except UnidentifiedImageError as exc:
+        raise ExternalToolError(f"Unable to read image metadata for {path}") from exc
+
+
+def read_video_meta(path: Path) -> Dict[str, Any]:
+    """Return basic metadata for a video file."""
+
+    mime = "video/quicktime" if path.suffix.lower() in {".mov", ".qt"} else "video/mp4"
+    return {
+        "mime": mime,
+        "dur": None,
+        "codec": None,
+        "content_id": None,
+        "still_image_time": None,
+    }

--- a/src/iPhoto/io/scanner.py
+++ b/src/iPhoto/io/scanner.py
@@ -1,0 +1,57 @@
+"""Directory scanner producing index rows."""
+
+from __future__ import annotations
+
+import mimetypes
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List
+
+from ..config import WORK_DIR_NAME
+from ..utils.hashutils import file_xxh3
+from ..utils.pathutils import ensure_work_dir, is_excluded, should_include
+from .metadata import read_image_meta, read_video_meta
+
+
+def _gather_file_paths(root: Path) -> Iterator[Path]:
+    for path in root.rglob("*"):
+        if path.is_file():
+            yield path
+
+
+def scan_album(
+    root: Path,
+    include_globs: Iterable[str],
+    exclude_globs: Iterable[str],
+) -> Iterator[Dict[str, Any]]:
+    """Yield index rows for all matching assets in *root*."""
+
+    ensure_work_dir(root, WORK_DIR_NAME)
+    for file_path in _gather_file_paths(root):
+        if WORK_DIR_NAME in file_path.parts:
+            continue
+        if is_excluded(file_path, exclude_globs, root=root):
+            continue
+        if not should_include(file_path, include_globs, exclude_globs, root=root):
+            continue
+        yield _build_row(root, file_path)
+
+
+def _build_row(root: Path, file_path: Path) -> Dict[str, Any]:
+    rel = file_path.relative_to(root).as_posix()
+    stat = file_path.stat()
+    base_row: Dict[str, Any] = {
+        "rel": rel,
+        "bytes": stat.st_size,
+        "dt": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat().replace(
+            "+00:00", "Z"
+        ),
+        "id": f"as_{file_xxh3(file_path)}",
+        "mime": mimetypes.guess_type(file_path.name)[0],
+    }
+    lower = file_path.suffix.lower()
+    if lower in {".heic", ".jpg", ".jpeg", ".png"}:
+        base_row.update(read_image_meta(file_path))
+    elif lower in {".mov", ".mp4", ".m4v", ".qt"}:
+        base_row.update(read_video_meta(file_path))
+    return base_row

--- a/src/iPhoto/models/album.py
+++ b/src/iPhoto/models/album.py
@@ -1,0 +1,73 @@
+"""Album manifest handling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from ..cache.lock import FileLock
+from ..config import ALBUM_MANIFEST_NAMES, WORK_DIR_NAME
+from ..errors import AlbumNotFoundError
+from ..schemas import validate_album
+from ..utils.jsonio import read_json, write_json
+
+
+@dataclass(slots=True)
+class Album:
+    """Represents an album loaded from disk."""
+
+    root: Path
+    manifest: Dict[str, Any]
+
+    @staticmethod
+    def open(root: Path) -> "Album":
+        if not root.exists():
+            raise AlbumNotFoundError(f"Album directory does not exist: {root}")
+        manifest_path = Album._find_manifest(root)
+        if manifest_path:
+            manifest = read_json(manifest_path)
+        else:
+            manifest = {
+                "schema": "iPhoto/album@1",
+                "title": root.name,
+                "filters": {},
+            }
+        validate_album(manifest)
+        return Album(root, manifest)
+
+    @staticmethod
+    def _find_manifest(root: Path) -> Optional[Path]:
+        for name in ALBUM_MANIFEST_NAMES:
+            candidate = root / name
+            if candidate.exists():
+                return candidate
+        return None
+
+    def save(self) -> Path:
+        """Persist the manifest to disk."""
+
+        path = self._find_manifest(self.root) or (self.root / ALBUM_MANIFEST_NAMES[0])
+        work_dir = self.root / WORK_DIR_NAME / "manifest.bak"
+        now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        self.manifest.setdefault("created", now)
+        self.manifest["modified"] = now
+        validate_album(self.manifest)
+        with FileLock(self.root, "manifest"):
+            write_json(path, self.manifest, backup_dir=work_dir)
+        return path
+
+    # High-level helpers -------------------------------------------------
+
+    def set_cover(self, rel: str) -> None:
+        self.manifest["cover"] = rel
+
+    def add_featured(self, ref: str) -> None:
+        featured = self.manifest.setdefault("featured", [])
+        if ref not in featured:
+            featured.append(ref)
+
+    def remove_featured(self, ref: str) -> None:
+        featured = self.manifest.setdefault("featured", [])
+        self.manifest["featured"] = [item for item in featured if item != ref]

--- a/src/iPhoto/models/types.py
+++ b/src/iPhoto/models/types.py
@@ -1,0 +1,43 @@
+"""Data models used by iPhoto."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass(slots=True)
+class PhotoMeta:
+    rel: str
+    id: str
+    bytes: int
+    dt: Optional[str]
+    w: Optional[int]
+    h: Optional[int]
+    mime: Optional[str]
+    make: Optional[str]
+    model: Optional[str]
+    gps: Optional[Dict[str, float]]
+    content_id: Optional[str]
+
+
+@dataclass(slots=True)
+class VideoMeta:
+    rel: str
+    id: str
+    bytes: int
+    dur: Optional[float]
+    mime: Optional[str]
+    codec: Optional[str]
+    content_id: Optional[str]
+    still_image_time: Optional[float]
+
+
+@dataclass(slots=True)
+class LiveGroup:
+    id: str
+    still: str
+    motion: str
+    content_id: Optional[str]
+    still_image_time: Optional[float]
+    confidence: float

--- a/src/iPhoto/schemas/__init__.py
+++ b/src/iPhoto/schemas/__init__.py
@@ -1,0 +1,32 @@
+"""Schema validation helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from ..config import SCHEMA_DIR
+from ..errors import ManifestInvalidError
+
+_ALBUM_VALIDATOR: Draft202012Validator | None = None
+
+
+def _load_validator(name: str) -> Draft202012Validator:
+    schema_path = SCHEMA_DIR / name
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    return Draft202012Validator(schema)
+
+
+def validate_album(document: dict[str, Any]) -> None:
+    """Validate an album manifest and raise :class:`ManifestInvalidError` on failure."""
+
+    global _ALBUM_VALIDATOR
+    if _ALBUM_VALIDATOR is None:
+        _ALBUM_VALIDATOR = _load_validator("album.schema.json")
+    errors = sorted(_ALBUM_VALIDATOR.iter_errors(document), key=lambda err: err.path)
+    if errors:
+        messages = "; ".join(error.message for error in errors)
+        raise ManifestInvalidError(messages)

--- a/src/iPhoto/schemas/album.schema.json
+++ b/src/iPhoto/schemas/album.schema.json
@@ -1,0 +1,44 @@
+{
+  "$id": "iPhoto/album.schema.json",
+  "type": "object",
+  "required": ["schema", "title"],
+  "properties": {
+    "schema": { "const": "iPhoto/album@1" },
+    "id": { "type": "string" },
+    "title": { "type": "string", "minLength": 1 },
+    "description": { "type": "string" },
+    "created": { "type": "string", "format": "date-time" },
+    "modified": { "type": "string", "format": "date-time" },
+    "cover": { "type": "string" },
+    "featured": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "order": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "filters": {
+      "type": "object",
+      "properties": {
+        "include": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "exclude": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "virtual_groups": { "type": "array" },
+    "tags": { "type": "array", "items": { "type": "string" } },
+    "people": { "type": "array", "items": { "type": "string" } },
+    "ui": { "type": "object" },
+    "write_policy": { "type": "object" },
+    "conflict": { "type": "object" },
+    "custom": { "type": "object" }
+  },
+  "additionalProperties": false
+}

--- a/src/iPhoto/schemas/links.schema.json
+++ b/src/iPhoto/schemas/links.schema.json
@@ -1,0 +1,28 @@
+{
+  "$id": "iPhoto/links.schema.json",
+  "type": "object",
+  "required": ["schema"],
+  "properties": {
+    "schema": { "const": "iPhoto/links@1" },
+    "live_groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "still", "motion"],
+        "properties": {
+          "id": { "type": "string" },
+          "still": { "type": "string" },
+          "motion": { "type": "string" },
+          "content_id": { "type": "string" },
+          "still_image_time": { "type": "number" },
+          "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "clips": {
+      "type": "array"
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/iPhoto/utils/deps.py
+++ b/src/iPhoto/utils/deps.py
@@ -1,0 +1,59 @@
+"""Utilities for optional third-party dependencies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class PillowSupport:
+    """Container exposing Pillow objects when the library is available."""
+
+    Image: Any
+    ImageOps: Any
+    ImageQt: Any
+    UnidentifiedImageError: Any
+
+
+@lru_cache(maxsize=1)
+def load_pillow() -> Optional[PillowSupport]:
+    """Return Pillow helpers when the dependency can be imported safely.
+
+    Some Windows Python distributions ship without the optional ``_ctypes``
+    extension, which in turn prevents Pillow from importing. Importing Pillow in
+    that scenario raises ``ImportError`` with a message similar to ``DLL load
+    failed while importing _ctypes``. Importing ``_ctypes`` eagerly allows us to
+    detect that situation and gracefully disable Pillow-backed features without
+    surfacing the exception to callers.
+    """
+
+    try:
+        import _ctypes  # type: ignore  # noqa: F401 - only used to test availability
+    except ImportError:
+        return None
+
+    try:
+        from PIL import Image, ImageOps, UnidentifiedImageError
+        from PIL.ImageQt import ImageQt
+    except Exception:  # pragma: no cover - optional dependency missing or broken
+        return None
+
+    try:  # pragma: no cover - pillow-heif optional
+        from pillow_heif import register_heif_opener
+    except Exception:  # pragma: no cover - pillow-heif not installed
+        register_heif_opener = None
+    else:
+        try:
+            register_heif_opener()
+        except Exception:
+            # ``pillow-heif`` is optional; ignore registration failures.
+            pass
+
+    return PillowSupport(
+        Image=Image,
+        ImageOps=ImageOps,
+        ImageQt=ImageQt,
+        UnidentifiedImageError=UnidentifiedImageError,
+    )

--- a/src/iPhoto/utils/ffmpeg.py
+++ b/src/iPhoto/utils/ffmpeg.py
@@ -59,8 +59,11 @@ def extract_video_frame(
     if scale is not None:
         width, height = scale
         if width > 0 and height > 0:
+            # Avoid single-quoted filter expressions because ``ffmpeg`` on Windows does not
+            # interpret them the same way as Unix shells. Passing the raw expression keeps the
+            # command portable across platforms when using ``subprocess`` with ``shell=False``.
             filters.append(
-                "scale='min({w},iw)':'min({h},ih)':force_original_aspect_ratio=decrease".format(
+                "scale=min({w},iw):min({h},ih):force_original_aspect_ratio=decrease".format(
                     w=width,
                     h=height,
                 )

--- a/src/iPhoto/utils/ffmpeg.py
+++ b/src/iPhoto/utils/ffmpeg.py
@@ -1,0 +1,111 @@
+"""Lightweight wrappers around the ``ffmpeg`` toolchain."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence
+
+from ..errors import ExternalToolError
+
+_FFMPEG_LOG_LEVEL = "error"
+
+
+def _run_command(command: Sequence[str]) -> subprocess.CompletedProcess[bytes]:
+    """Execute *command* and return the completed process."""
+
+    try:
+        process = subprocess.run(
+            list(command),
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - depends on environment
+        raise ExternalToolError("ffmpeg executable not found on PATH") from exc
+    return process
+
+
+def extract_video_frame(
+    source: Path,
+    *,
+    at: Optional[float] = None,
+    scale: Optional[tuple[int, int]] = None,
+) -> bytes:
+    """Return a PNG frame extracted from *source*.
+
+    Parameters
+    ----------
+    source:
+        Path to the input video file.
+    at:
+        Timestamp in seconds to sample. When ``None`` the first frame is used.
+    scale:
+        Optional ``(width, height)`` hint used to scale the output frame while
+        preserving aspect ratio.
+    """
+
+    command: list[str] = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        _FFMPEG_LOG_LEVEL,
+    ]
+    if at is not None:
+        command += ["-ss", f"{max(at, 0):.3f}"]
+    command += ["-i", str(source), "-frames:v", "1"]
+    filters: list[str] = []
+    if scale is not None:
+        width, height = scale
+        if width > 0 and height > 0:
+            filters.append(
+                "scale='min({w},iw)':'min({h},ih)':force_original_aspect_ratio=decrease".format(
+                    w=width,
+                    h=height,
+                )
+            )
+    filters.append("format=rgba")
+    if filters:
+        command += ["-vf", ",".join(filters)]
+    command += ["-f", "image2", "-vcodec", "png", "pipe:1"]
+
+    process = _run_command(command)
+    if process.returncode != 0 or not process.stdout:
+        stderr = process.stderr.decode("utf-8", "ignore").strip()
+        raise ExternalToolError(
+            f"ffmpeg failed to extract frame from {source}: {stderr or 'unknown error'}"
+        )
+    return bytes(process.stdout)
+
+
+def probe_media(source: Path) -> Dict[str, Any]:
+    """Return ffprobe metadata for *source*.
+
+    The JSON structure mirrors ffprobe's ``show_format`` and ``show_streams``
+    output. ``ExternalToolError`` is raised when the toolchain is unavailable or
+    returns an error.
+    """
+
+    command = [
+        "ffprobe",
+        "-hide_banner",
+        "-loglevel",
+        _FFMPEG_LOG_LEVEL,
+        "-print_format",
+        "json",
+        "-show_format",
+        "-show_streams",
+        str(source),
+    ]
+
+    process = _run_command(command)
+    if process.returncode != 0 or not process.stdout:
+        stderr = process.stderr.decode("utf-8", "ignore").strip()
+        raise ExternalToolError(
+            f"ffprobe failed to inspect {source}: {stderr or 'unknown error'}"
+        )
+    try:
+        return json.loads(process.stdout.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ExternalToolError("ffprobe returned invalid JSON output") from exc

--- a/src/iPhoto/utils/hashutils.py
+++ b/src/iPhoto/utils/hashutils.py
@@ -1,0 +1,20 @@
+"""Hashing utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import xxhash
+
+
+def file_xxh3(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
+    """Return the XXH3 128-bit hash of *path*."""
+
+    hasher = xxhash.xxh3_128()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(chunk_size)
+            if not chunk:
+                break
+            hasher.update(chunk)
+    return hasher.hexdigest()

--- a/src/iPhoto/utils/jsonio.py
+++ b/src/iPhoto/utils/jsonio.py
@@ -1,0 +1,53 @@
+"""Helpers for JSON input/output with atomic writes and backups."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ..errors import ManifestInvalidError
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    """Read JSON from *path* and return a dictionary."""
+
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except FileNotFoundError as exc:
+        raise ManifestInvalidError(f"JSON file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ManifestInvalidError(f"Invalid JSON data in {path}") from exc
+
+
+def atomic_write_text(path: Path, data: str) -> None:
+    """Atomically write *data* into *path*."""
+
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tmp_path.open("w", encoding="utf-8") as handle:
+        handle.write(data)
+        handle.flush()
+        os.fsync(handle.fileno())
+    tmp_path.replace(path)
+
+
+def _write_backup(path: Path, backup_dir: Path) -> None:
+    if not path.exists():
+        return
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup_path = backup_dir / f"{timestamp}{path.suffix}"
+    backup_path.write_bytes(path.read_bytes())
+
+
+def write_json(path: Path, data: dict[str, Any], *, backup_dir: Path | None = None) -> None:
+    """Write *data* into *path* atomically with optional backups."""
+
+    if backup_dir is not None:
+        _write_backup(path, backup_dir)
+    payload = json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True)
+    atomic_write_text(path, payload)

--- a/src/iPhoto/utils/logging.py
+++ b/src/iPhoto/utils/logging.py
@@ -1,0 +1,23 @@
+"""Logging helpers for iPhoto."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+_LOGGER: Optional[logging.Logger] = None
+
+
+def get_logger() -> logging.Logger:
+    """Return a module-level logger configured for iPhoto."""
+
+    global _LOGGER
+    if _LOGGER is None:
+        _LOGGER = logging.getLogger("iPhoto")
+        if not _LOGGER.handlers:
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+            handler.setFormatter(formatter)
+            _LOGGER.addHandler(handler)
+        _LOGGER.setLevel(logging.INFO)
+    return _LOGGER

--- a/src/iPhoto/utils/pathutils.py
+++ b/src/iPhoto/utils/pathutils.py
@@ -1,0 +1,59 @@
+"""Utilities for working with filesystem paths inside iPhoto."""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from pathlib import Path
+from typing import Iterable, Iterator
+
+
+def _expand(pattern: str) -> Iterator[str]:
+    match = re.search(r"\{([^}]+)\}", pattern)
+    if not match:
+        yield pattern
+        return
+    prefix = pattern[: match.start()]
+    suffix = pattern[match.end() :]
+    for option in match.group(1).split(","):
+        yield from _expand(prefix + option + suffix)
+
+
+def is_excluded(path: Path, globs: Iterable[str], *, root: Path) -> bool:
+    """Return ``True`` if *path* should be excluded based on *globs*.
+
+    The function works on relative POSIX-style paths to provide consistent
+    behaviour across operating systems.
+    """
+
+    rel = path.relative_to(root).as_posix()
+    for pattern in globs:
+        for expanded in _expand(pattern):
+            if fnmatch.fnmatch(rel, expanded):
+                return True
+            if expanded.startswith("**/") and fnmatch.fnmatch(rel, expanded[3:]):
+                return True
+    return False
+
+
+def should_include(path: Path, include_globs: Iterable[str], exclude_globs: Iterable[str], *, root: Path) -> bool:
+    """Return ``True`` if *path* should be scanned."""
+
+    if is_excluded(path, exclude_globs, root=root):
+        return False
+    rel = path.relative_to(root).as_posix()
+    for pattern in include_globs:
+        for expanded in _expand(pattern):
+            if fnmatch.fnmatch(rel, expanded):
+                return True
+            if expanded.startswith("**/") and fnmatch.fnmatch(rel, expanded[3:]):
+                return True
+    return False
+
+
+def ensure_work_dir(root: Path, name: str = ".iPhoto") -> Path:
+    """Ensure that the album work directory exists and return it."""
+
+    work_dir = root / name
+    work_dir.mkdir(parents=True, exist_ok=True)
+    return work_dir

--- a/tests/test_album_manifest.py
+++ b/tests/test_album_manifest.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from iPhoto.models.album import Album
+
+
+def test_open_temp_album(tmp_path: Path) -> None:
+    album = Album.open(tmp_path)
+    assert album.manifest["title"] == tmp_path.name
+
+
+def test_save_manifest(tmp_path: Path) -> None:
+    album = Album.open(tmp_path)
+    album.set_cover("IMG_0001.JPG")
+    path = album.save()
+    assert path.exists()
+    saved = Album.open(tmp_path)
+    assert saved.manifest["cover"] == "IMG_0001.JPG"

--- a/tests/test_gui_app.py
+++ b/tests/test_gui_app.py
@@ -8,6 +8,8 @@ from PIL import Image
 
 pytest.importorskip("PySide6", reason="PySide6 is required for GUI tests", exc_type=ImportError)
 pytest.importorskip("PySide6.QtWidgets", reason="Qt widgets not available", exc_type=ImportError)
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import QApplication  # type: ignore  # noqa: E402
 
 from iPhoto.gui.facade import AppFacade
@@ -54,3 +56,6 @@ def test_asset_model_populates_rows(tmp_path: Path, qapp: QApplication) -> None:
     index = model.index(0, 0)
     assert model.data(index, Roles.REL) == "IMG_2001.JPG"
     assert model.data(index, Roles.FEATURED) is False
+    decoration = model.data(index, Qt.DecorationRole)
+    assert isinstance(decoration, QPixmap)
+    assert not decoration.isNull()

--- a/tests/test_gui_app.py
+++ b/tests/test_gui_app.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+pytest.importorskip("PySide6", reason="PySide6 is required for GUI tests", exc_type=ImportError)
+pytest.importorskip("PySide6.QtWidgets", reason="Qt widgets not available", exc_type=ImportError)
+from PySide6.QtWidgets import QApplication  # type: ignore  # noqa: E402
+
+from iPhoto.gui.facade import AppFacade
+from iPhoto.gui.ui.models.asset_model import AssetModel, Roles
+
+
+def _create_image(path: Path) -> None:
+    image = Image.new("RGB", (8, 8), color="blue")
+    image.save(path)
+
+
+@pytest.fixture(scope="module")
+def qapp() -> QApplication:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+
+
+def test_facade_open_album_emits_signals(tmp_path: Path, qapp: QApplication) -> None:
+    asset = tmp_path / "IMG_1001.JPG"
+    _create_image(asset)
+    facade = AppFacade()
+    received: list[str] = []
+    facade.albumOpened.connect(lambda _: received.append("opened"))
+    facade.indexUpdated.connect(lambda _: received.append("index"))
+    facade.linksUpdated.connect(lambda _: received.append("links"))
+    album = facade.open_album(tmp_path)
+    qapp.processEvents()
+    assert album is not None
+    assert (tmp_path / ".iPhoto" / "index.jsonl").exists()
+    assert "opened" in received and "index" in received
+
+
+def test_asset_model_populates_rows(tmp_path: Path, qapp: QApplication) -> None:
+    asset = tmp_path / "IMG_2001.JPG"
+    _create_image(asset)
+    facade = AppFacade()
+    model = AssetModel(facade)
+    facade.open_album(tmp_path)
+    qapp.processEvents()
+    assert model.rowCount() == 1
+    index = model.index(0, 0)
+    assert model.data(index, Roles.REL) == "IMG_2001.JPG"
+    assert model.data(index, Roles.FEATURED) is False

--- a/tests/test_gui_app.py
+++ b/tests/test_gui_app.py
@@ -4,7 +4,14 @@ import os
 from pathlib import Path
 
 import pytest
-from PIL import Image
+
+try:
+    from PIL import Image
+except Exception as exc:  # pragma: no cover - pillow missing or broken
+    pytest.skip(
+        f"Pillow unavailable for GUI tests: {exc}",
+        allow_module_level=True,
+    )
 
 pytest.importorskip("PySide6", reason="PySide6 is required for GUI tests", exc_type=ImportError)
 pytest.importorskip("PySide6.QtWidgets", reason="Qt widgets not available", exc_type=ImportError)

--- a/tests/test_pairing_live.py
+++ b/tests/test_pairing_live.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from iPhoto.core.pairing import pair_live
+
+
+def iso(ts: datetime) -> str:
+    return ts.replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def test_pairing_prefers_content_id() -> None:
+    dt = iso(datetime(2024, 1, 1, 12, 0, 0))
+    rows = [
+        {
+            "rel": "IMG_0001.HEIC",
+            "mime": "image/heic",
+            "dt": dt,
+            "content_id": "CID1",
+        },
+        {
+            "rel": "IMG_0001.MOV",
+            "mime": "video/quicktime",
+            "dt": dt,
+            "content_id": "CID1",
+            "dur": 1.5,
+            "still_image_time": 0.1,
+        },
+    ]
+    groups = pair_live(rows)
+    assert len(groups) == 1
+    group = groups[0]
+    assert group.still == "IMG_0001.HEIC"
+    assert group.motion == "IMG_0001.MOV"
+    assert group.content_id == "CID1"

--- a/tests/test_scanner_index.py
+++ b/tests/test_scanner_index.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from PIL import Image
+
+from iPhoto.config import DEFAULT_EXCLUDE, DEFAULT_INCLUDE
+from iPhoto.io.scanner import scan_album
+
+
+def create_image(path: Path) -> None:
+    img = Image.new("RGB", (10, 10), color="red")
+    img.save(path)
+
+
+def test_scan_album_produces_rows(tmp_path: Path) -> None:
+    asset = tmp_path / "IMG_0001.JPG"
+    create_image(asset)
+    rows = list(scan_album(tmp_path, DEFAULT_INCLUDE, DEFAULT_EXCLUDE))
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["rel"] == "IMG_0001.JPG"
+    assert row["w"] == 10 and row["h"] == 10

--- a/tests/test_scanner_index.py
+++ b/tests/test_scanner_index.py
@@ -2,7 +2,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from PIL import Image
+import pytest
+
+try:
+    from PIL import Image
+except Exception as exc:  # pragma: no cover - pillow missing or broken
+    pytest.skip(
+        f"Pillow unavailable for scanner tests: {exc}",
+        allow_module_level=True,
+    )
 
 from iPhoto.config import DEFAULT_EXCLUDE, DEFAULT_INCLUDE
 from iPhoto.io.scanner import scan_album

--- a/tests/test_scanner_index.py
+++ b/tests/test_scanner_index.py
@@ -12,8 +12,8 @@ except Exception as exc:  # pragma: no cover - pillow missing or broken
         allow_module_level=True,
     )
 
-from iPhoto.config import DEFAULT_EXCLUDE, DEFAULT_INCLUDE
-from iPhoto.io.scanner import scan_album
+from iPhotos.src.iPhoto.config import DEFAULT_EXCLUDE, DEFAULT_INCLUDE
+from iPhotos.src.iPhoto.io.scanner import scan_album
 
 
 def create_image(path: Path) -> None:

--- a/tests/test_utils_deps.py
+++ b/tests/test_utils_deps.py
@@ -1,0 +1,7 @@
+from iPhoto.utils.deps import debugger_prerequisites
+
+
+def test_debugger_prerequisites_detects_ctypes_support():
+    info = debugger_prerequisites()
+    assert info.has_ctypes is True
+    assert info.message is None


### PR DESCRIPTION
## Summary
- scaffold the Python package with configuration, schemas, and JSON utilities
- implement album manifest handling, directory scanning, and Live Photo pairing behind a Typer CLI
- add unit tests covering manifest persistence, scanner output, and pairing logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfd057c72c832f8f73204a930cc77f