### PR TITLE
Replace media controls and library sidebar icons with bundled SVGs

### DIFF
--- a/src/iPhoto/gui/ui/icons.py
+++ b/src/iPhoto/gui/ui/icons.py
@@ -1,0 +1,113 @@
+"""Utility helpers for loading bundled SVG icons."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+from PySide6.QtCore import QSize, Qt
+from PySide6.QtGui import QColor, QIcon, QPainter, QPixmap, QTransform
+from PySide6.QtSvg import QSvgRenderer
+
+ICON_DIRECTORY = Path(__file__).resolve().parent / "icon"
+
+_IconKey = Tuple[str, Optional[Tuple[int, int, int, int]], Optional[Tuple[int, int]], bool]
+_ICON_CACHE: Dict[_IconKey, QIcon] = {}
+
+
+def load_icon(
+    name: str,
+    *,
+    color: str | Tuple[int, int, int] | Tuple[int, int, int, int] | None = None,
+    size: Tuple[int, int] | None = None,
+    mirror_horizontal: bool = False,
+) -> QIcon:
+    """Return a :class:`QIcon` for *name* from the bundled icon directory.
+
+    Parameters
+    ----------
+    name:
+        File name (including the ``.svg`` suffix) of the icon to load.
+    color:
+        Optional colour tint applied to the icon. Accepts hex strings (``"#RRGGBB"``)
+        or tuples representing RGB/RGBA components. When omitted, the original
+        colours from the SVG asset are preserved.
+    size:
+        Optional target size (width, height) used when rendering the SVG. When not
+        supplied, the intrinsic size declared in the SVG is used.
+    mirror_horizontal:
+        When ``True`` the resulting pixmap is mirrored horizontally. This is useful
+        for reusing directional icons (e.g. play/previous).
+    """
+
+    normalized_color = _normalize_color_key(color)
+    cache_key: _IconKey = (name, normalized_color, tuple(size) if size else None, mirror_horizontal)
+    if cache_key in _ICON_CACHE:
+        return _ICON_CACHE[cache_key]
+
+    path = ICON_DIRECTORY / name
+    if not path.exists():  # pragma: no cover - defensive guard
+        raise FileNotFoundError(f"Icon '{name}' not found in {ICON_DIRECTORY}")
+
+    if normalized_color is None and size is None and not mirror_horizontal:
+        icon = QIcon(str(path))
+        _ICON_CACHE[cache_key] = icon
+        return icon
+
+    renderer = QSvgRenderer(str(path))
+    target_size = QSize(*size) if size else renderer.defaultSize()
+    if not target_size.isValid():
+        target_size = QSize(64, 64)
+
+    pixmap = QPixmap(target_size)
+    pixmap.fill(Qt.GlobalColor.transparent)
+    painter = QPainter(pixmap)
+    renderer.render(painter)
+    painter.end()
+
+    if normalized_color is not None:
+        tint = QColor.fromRgb(*normalized_color)
+        tinted = QPixmap(pixmap.size())
+        tinted.fill(Qt.GlobalColor.transparent)
+        painter = QPainter(tinted)
+        painter.fillRect(tinted.rect(), tint)
+        painter.setCompositionMode(QPainter.CompositionMode.DestinationIn)
+        painter.drawPixmap(0, 0, pixmap)
+        painter.end()
+        pixmap = tinted
+
+    if mirror_horizontal:
+        transform = QTransform()
+        transform.scale(-1, 1)
+        pixmap = pixmap.transformed(transform, Qt.TransformationMode.SmoothTransformation)
+
+    icon = QIcon()
+    icon.addPixmap(pixmap)
+    _ICON_CACHE[cache_key] = icon
+    return icon
+
+
+def _normalize_color_key(
+    color: str | Tuple[int, int, int] | Tuple[int, int, int, int] | None
+) -> Tuple[int, int, int, int] | None:
+    if color is None:
+        return None
+    qcolor = QColor()
+    if isinstance(color, str):
+        qcolor = QColor(color)
+    elif isinstance(color, tuple):
+        if len(color) == 3:
+            qcolor = QColor(color[0], color[1], color[2])
+        elif len(color) == 4:
+            qcolor = QColor(color[0], color[1], color[2], color[3])
+        else:  # pragma: no cover - defensive guard
+            raise ValueError("Colour tuples must be RGB or RGBA")
+    else:  # pragma: no cover - defensive guard
+        raise TypeError("Colour must be a hex string or RGB/RGBA tuple")
+    if not qcolor.isValid():  # pragma: no cover - defensive guard
+        raise ValueError(f"Invalid colour specification: {color!r}")
+    return (qcolor.red(), qcolor.green(), qcolor.blue(), qcolor.alpha())
+
+
+__all__ = ["load_icon"]
+

--- a/src/iPhoto/gui/ui/icons.py
+++ b/src/iPhoto/gui/ui/icons.py
@@ -71,7 +71,7 @@ def load_icon(
         tinted.fill(Qt.GlobalColor.transparent)
         painter = QPainter(tinted)
         painter.fillRect(tinted.rect(), tint)
-        painter.setCompositionMode(QPainter.CompositionMode.DestinationIn)
+        painter.setCompositionMode(QPainter.CompositionMode_DestinationIn)
         painter.drawPixmap(0, 0, pixmap)
         painter.end()
         pixmap = tinted

--- a/src/iPhoto/gui/ui/models/album_tree_model.py
+++ b/src/iPhoto/gui/ui/models/album_tree_model.py
@@ -11,6 +11,7 @@ from PySide6.QtCore import QAbstractItemModel, QModelIndex, QObject, Qt
 
 from ....library.manager import LibraryManager
 from ....library.tree import AlbumNode
+from ..icons import load_icon
 
 
 class AlbumTreeRole(int, Enum):
@@ -74,6 +75,15 @@ class AlbumTreeModel(QAbstractItemModel):
 
     TRAILING_STATIC_NODES: tuple[str, ...] = ("Recently Deleted",)
 
+    _STATIC_ICON_NAMES: dict[str, str] = {
+        "All Photos": "photo.on.rectangle.svg",
+        "Videos": "video.fill.svg",
+        "Live Photos": "livephoto.svg",
+        "Favorites": "suit.heart.fill.svg",
+        "Recently Deleted": "trash.svg",
+    }
+    _STATIC_ICON_COLOR = "#1e73ff"
+
     def __init__(self, library: LibraryManager, parent: QObject | None = None) -> None:
         super().__init__(parent)
         self._library = library
@@ -117,6 +127,12 @@ class AlbumTreeModel(QAbstractItemModel):
             return item.title
         if role == Qt.ItemDataRole.ToolTipRole and item.album is not None:
             return str(item.album.path)
+        if role == Qt.ItemDataRole.DecorationRole:
+            icon_name = None
+            if item.node_type == NodeType.STATIC:
+                icon_name = self._STATIC_ICON_NAMES.get(item.title)
+            if icon_name:
+                return load_icon(icon_name, color=self._STATIC_ICON_COLOR)
         if role == AlbumTreeRole.NODE_TYPE:
             return item.node_type
         if role == AlbumTreeRole.ALBUM_NODE:

--- a/src/iPhoto/gui/ui/models/album_tree_model.py
+++ b/src/iPhoto/gui/ui/models/album_tree_model.py
@@ -83,6 +83,7 @@ class AlbumTreeModel(QAbstractItemModel):
         "Recently Deleted": "trash.svg",
     }
     _STATIC_ICON_COLOR = "#1e73ff"
+    _STATIC_ICON_SIZE: tuple[int, int] = (20, 20)
 
     def __init__(self, library: LibraryManager, parent: QObject | None = None) -> None:
         super().__init__(parent)
@@ -132,7 +133,11 @@ class AlbumTreeModel(QAbstractItemModel):
             if item.node_type == NodeType.STATIC:
                 icon_name = self._STATIC_ICON_NAMES.get(item.title)
             if icon_name:
-                return load_icon(icon_name, color=self._STATIC_ICON_COLOR)
+                return load_icon(
+                    icon_name,
+                    color=self._STATIC_ICON_COLOR,
+                    size=self._STATIC_ICON_SIZE,
+                )
         if role == AlbumTreeRole.NODE_TYPE:
             return item.node_type
         if role == AlbumTreeRole.ALBUM_NODE:


### PR DESCRIPTION
## Summary
- add a reusable loader for the bundled SVG icon assets
- update the media player bar to use the new play/pause/volume icons with dynamic tooltips
- show the photo, video, live, favorites, and recently deleted icons inside the library sidebar

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'iPhotos')*

------
https://chatgpt.com/codex/tasks/task_e_68e182e3e220832fb2c7c9f119c8eea0