### PR TITLE
Fix AssetGrid long press coordinate handling

### DIFF
--- a/src/iPhoto/config.py
+++ b/src/iPhoto/config.py
@@ -26,6 +26,7 @@ LONG_PRESS_THRESHOLD_MS: Final[int] = 350
 PREVIEW_WINDOW_DEFAULT_WIDTH: Final[int] = 640
 PREVIEW_WINDOW_MUTED: Final[bool] = True
 PREVIEW_WINDOW_CLOSE_DELAY_MS: Final[int] = 150
+PREVIEW_WINDOW_CORNER_RADIUS: Final[int] = 18
 
 # Maximum number of bytes to preload into memory for the active video. When the
 # file on disk is smaller than this threshold the media controller will stream

--- a/src/iPhoto/gui/ui/media/media_controller.py
+++ b/src/iPhoto/gui/ui/media/media_controller.py
@@ -70,6 +70,13 @@ class MediaController(QObject):
     def set_video_output(self, widget: object) -> None:
         """Display video frames on *widget*."""
 
+        sink_getter = getattr(widget, "videoSink", None)
+        if callable(sink_getter):
+            sink = sink_getter()
+            if sink is not None:
+                self._player.setVideoOutput(sink)
+                return
+
         self._player.setVideoOutput(widget)
 
     def load(self, path: Path) -> None:

--- a/src/iPhoto/gui/ui/widgets/asset_grid.py
+++ b/src/iPhoto/gui/ui/widgets/asset_grid.py
@@ -99,7 +99,9 @@ class AssetGrid(QListView):
         else:  # Qt < 6 fallback, kept for safety in tests
             widget_pos = event.pos()
 
-        target = event.widget()
+        widget_getter = getattr(event, "widget", None)
+        target = widget_getter() if callable(widget_getter) else None
+
         if target is self.viewport():
             return widget_pos
         if target is self:

--- a/src/iPhoto/gui/ui/widgets/asset_grid.py
+++ b/src/iPhoto/gui/ui/widgets/asset_grid.py
@@ -94,29 +94,43 @@ class AssetGrid(QListView):
     def _viewport_pos(self, event: QMouseEvent) -> QPoint:
         """Return the event position mapped into viewport coordinates."""
 
+        viewport = self.viewport()
+
+        def _validated(point: Optional[QPoint]) -> Optional[QPoint]:
+            if point is None:
+                return None
+            if viewport.rect().contains(point):
+                return point
+            return None
+
         if hasattr(event, "position"):
-            # Qt 6 synthesised events (e.g. via QTest) always provide widget-local
-            # coordinates through ``position``. Prefer those so we do not depend on
-            # a functioning global mapping, which may be unavailable on headless
-            # platforms used during testing.
-            return event.position().toPoint()
+            candidate = _validated(event.position().toPoint())
+            if candidate is not None:
+                return candidate
 
         if hasattr(event, "pos"):
-            return event.pos()
+            candidate = _validated(event.pos())
+            if candidate is not None:
+                return candidate
+
+        global_point: Optional[QPoint] = None
 
         global_position = getattr(event, "globalPosition", None)
         if callable(global_position):
             global_point = global_position().toPoint()
         elif global_position is not None:
             global_point = global_position.toPoint()
-        else:
-            global_point = None
+
+        if global_point is None and hasattr(event, "globalPos"):
+            global_point = event.globalPos()
 
         if global_point is not None:
-            return self.viewport().mapFromGlobal(global_point)
+            mapped = viewport.mapFromGlobal(global_point)
+            candidate = _validated(mapped)
+            if candidate is not None:
+                return candidate
 
-        if hasattr(event, "globalPos"):
-            return self.viewport().mapFromGlobal(event.globalPos())
-
-        # Fallback for any other exotic QMouseEvent implementations.
+        # Fallback for any other exotic QMouseEvent implementations. At this point
+        # we have no reliable coordinate system information, so best-effort return
+        # of the event's integer components is the safest option.
         return QPoint(event.x(), event.y())

--- a/src/iPhoto/gui/ui/widgets/preview_window.py
+++ b/src/iPhoto/gui/ui/widgets/preview_window.py
@@ -66,6 +66,9 @@ class PreviewWindow(QWidget):
         self._chrome = QWidget(self)
         self._chrome.setObjectName("previewChrome")
         self._chrome.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        self._chrome.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground, True)
+        self._chrome.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self._chrome.setAutoFillBackground(False)
         self._chrome.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
 
         chrome_layout = QVBoxLayout(self._chrome)
@@ -73,6 +76,12 @@ class PreviewWindow(QWidget):
 
         self._video_widget = QVideoWidget(self._chrome)
         self._video_widget.setObjectName("previewVideo")
+        self._video_widget.setAttribute(Qt.WidgetAttribute.WA_DontCreateNativeAncestors, True)
+        self._video_widget.setAttribute(Qt.WidgetAttribute.WA_NativeWindow, False)
+        self._video_widget.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground, True)
+        self._video_widget.setAttribute(Qt.WidgetAttribute.WA_OpaquePaintEvent, False)
+        self._video_widget.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self._video_widget.setAutoFillBackground(False)
         self._video_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         chrome_layout.addWidget(self._video_widget)
 

--- a/src/iPhoto/gui/ui/widgets/preview_window.py
+++ b/src/iPhoto/gui/ui/widgets/preview_window.py
@@ -6,11 +6,18 @@ import importlib.util
 from pathlib import Path
 from typing import Optional
 
-from PySide6.QtCore import QPoint, QRect, Qt, QTimer
-from PySide6.QtWidgets import QSizePolicy, QVBoxLayout, QWidget
+from PySide6.QtCore import QPoint, QRect, QRectF, QSize, Qt, QTimer
+from PySide6.QtGui import QColor, QPainterPath, QRegion, QResizeEvent
+from PySide6.QtWidgets import (
+    QGraphicsDropShadowEffect,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
 
 from ....config import (
     PREVIEW_WINDOW_CLOSE_DELAY_MS,
+    PREVIEW_WINDOW_CORNER_RADIUS,
     PREVIEW_WINDOW_DEFAULT_WIDTH,
     PREVIEW_WINDOW_MUTED,
 )
@@ -43,13 +50,45 @@ class PreviewWindow(QWidget):
         self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating, True)
         self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
 
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
+        self._shadow_padding = 12
+        self._corner_radius = PREVIEW_WINDOW_CORNER_RADIUS
+        default_height = max(1, int(PREVIEW_WINDOW_DEFAULT_WIDTH * 9 / 16))
+        self._content_size = QSize(PREVIEW_WINDOW_DEFAULT_WIDTH, default_height)
 
-        self._video_widget = QVideoWidget(self)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(
+            self._shadow_padding,
+            self._shadow_padding,
+            self._shadow_padding,
+            self._shadow_padding,
+        )
+
+        self._chrome = QWidget(self)
+        self._chrome.setObjectName("previewChrome")
+        self._chrome.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        self._chrome.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+        chrome_layout = QVBoxLayout(self._chrome)
+        chrome_layout.setContentsMargins(0, 0, 0, 0)
+
+        self._video_widget = QVideoWidget(self._chrome)
+        self._video_widget.setObjectName("previewVideo")
         self._video_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        self._video_widget.setStyleSheet("background-color: black;")
-        layout.addWidget(self._video_widget)
+        chrome_layout.addWidget(self._video_widget)
+
+        layout.addWidget(self._chrome)
+
+        self._shadow_effect = QGraphicsDropShadowEffect(self)
+        self._shadow_effect.setBlurRadius(48.0)
+        self._shadow_effect.setOffset(0, 12)
+        self._shadow_effect.setColor(QColor(0, 0, 0, 120))
+        self._chrome.setGraphicsEffect(self._shadow_effect)
+
+        self._apply_palette()
+        self._apply_content_size(
+            self._content_size.width(),
+            self._content_size.height(),
+        )
 
         self._media = MediaController(self)
         self._media.set_video_output(self._video_widget)
@@ -75,7 +114,7 @@ class PreviewWindow(QWidget):
             width = max(PREVIEW_WINDOW_DEFAULT_WIDTH, at.width())
             height = max(int(width * 9 / 16), at.height())
             width = max(width, int(height * 16 / 9))
-            self.resize(width, height)
+            self._apply_content_size(width, height)
             center = at.center()
             origin = QPoint(center.x() - self.width() // 2, center.y() - self.height() // 2)
             origin = self._clamp_to_screen(origin)
@@ -83,7 +122,7 @@ class PreviewWindow(QWidget):
         else:
             width = PREVIEW_WINDOW_DEFAULT_WIDTH
             height = max(1, int(width * 9 / 16))
-            self.resize(width, height)
+            self._apply_content_size(width, height)
             if isinstance(at, QPoint):
                 origin = self._clamp_to_screen(at)
                 self.move(origin)
@@ -121,3 +160,64 @@ class PreviewWindow(QWidget):
             max(min_x, min(origin.x(), max_x)),
             max(min_y, min(origin.y(), max_y)),
         )
+
+    def resizeEvent(self, event: QResizeEvent) -> None:
+        super().resizeEvent(event)
+        self._update_masks()
+
+    def _apply_palette(self) -> None:
+        border_radius = self._corner_radius
+        inner_radius = max(0, border_radius - 2)
+        stylesheet = (
+            "PreviewWindow #previewChrome {"
+            " background-color: rgba(18, 18, 22, 220);"
+            f" border-radius: {border_radius}px;"
+            " border: 1px solid rgba(255, 255, 255, 36);"
+            " }\n"
+            "PreviewWindow #previewVideo {"
+            f" border-radius: {inner_radius}px;"
+            " background-color: black;"
+            " }"
+        )
+        self.setStyleSheet(stylesheet)
+
+    def _apply_content_size(self, content_width: int, content_height: int) -> None:
+        content_width = max(1, content_width)
+        content_height = max(1, content_height)
+        self._content_size = QSize(content_width, content_height)
+        self._chrome.setFixedSize(self._content_size)
+        total_width = self._content_size.width() + 2 * self._shadow_padding
+        total_height = self._content_size.height() + 2 * self._shadow_padding
+        if self.size() != QSize(total_width, total_height):
+            self.resize(total_width, total_height)
+        self._update_masks()
+
+    def _update_masks(self) -> None:
+        if self._chrome.width() <= 0 or self._chrome.height() <= 0:
+            self._chrome.clearMask()
+            self._video_widget.clearMask()
+            return
+
+        radius = self._corner_radius
+        chrome_path = QPainterPath()
+        chrome_path.addRoundedRect(
+            QRectF(self._chrome.rect()),
+            float(radius),
+            float(radius),
+        )
+        chrome_region = QRegion(chrome_path.toFillPolygon().toPolygon())
+        self._chrome.setMask(chrome_region)
+
+        if self._video_widget.width() <= 0 or self._video_widget.height() <= 0:
+            self._video_widget.clearMask()
+            return
+
+        inner_radius = max(0, radius - 2)
+        video_path = QPainterPath()
+        video_path.addRoundedRect(
+            QRectF(self._video_widget.rect()),
+            float(inner_radius),
+            float(inner_radius),
+        )
+        video_region = QRegion(video_path.toFillPolygon().toPolygon())
+        self._video_widget.setMask(video_region)

--- a/src/iPhoto/gui/ui/widgets/preview_window.py
+++ b/src/iPhoto/gui/ui/widgets/preview_window.py
@@ -43,7 +43,7 @@ class _RoundedVideoItem(QGraphicsVideoItem):
             )
         super().__init__()
         self._corner_radius = float(max(0, corner_radius))
-        self.setAspectRatioMode(Qt.AspectRatioMode.KeepAspectRatio)
+        self.setAspectRatioMode(Qt.AspectRatioMode.KeepAspectRatioByExpanding)
 
     def set_corner_radius(self, corner_radius: int) -> None:
         radius = float(max(0, corner_radius))
@@ -116,7 +116,7 @@ class _PreviewFrame(QWidget):
     def __init__(self, corner_radius: int, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
         self._corner_radius = max(0, corner_radius)
-        self._border_width = 2
+        self._border_width = 0
         self._background = QColor(18, 18, 22)
         self._border = QColor(255, 255, 255, 28)
 
@@ -124,12 +124,7 @@ class _PreviewFrame(QWidget):
         self.setAutoFillBackground(False)
 
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(
-            self._border_width,
-            self._border_width,
-            self._border_width,
-            self._border_width,
-        )
+        layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
         self._video_view = _VideoView(self._update_masks, corner_radius, self)
@@ -175,7 +170,7 @@ class _PreviewFrame(QWidget):
         self._update_masks()
 
     def _update_masks(self) -> None:
-        video_radius = max(0, self._corner_radius - self._border_width)
+        video_radius = max(0, self._corner_radius)
         self._video_view.video_item().set_corner_radius(video_radius)
         self.update()
 

--- a/tests/test_asset_grid_long_press.py
+++ b/tests/test_asset_grid_long_press.py
@@ -43,5 +43,18 @@ def test_asset_grid_long_press_emits_preview(qapp: QApplication) -> None:
 
     QTest.mousePress(grid.viewport(), Qt.MouseButton.LeftButton, pos=pos)
     assert preview_spy.wait(LONG_PRESS_THRESHOLD_MS + 800)
-    QTest.mouseRelease(grid.viewport(), Qt.MouseButton.LeftButton, pos=pos)
-    assert release_spy.wait(200)
+
+    qapp.processEvents()
+    global_pos = grid.viewport().mapToGlobal(pos)
+    target = QApplication.widgetAt(global_pos)
+    if target is None:
+        target = grid.viewport()
+        local_pos = pos
+    else:
+        local_pos = target.mapFromGlobal(global_pos)
+
+    QTest.mouseRelease(target, Qt.MouseButton.LeftButton, pos=local_pos)
+    if release_spy.count() == 0:
+        assert release_spy.wait(800)
+
+    assert release_spy.count() > 0

--- a/tests/test_asset_grid_long_press.py
+++ b/tests/test_asset_grid_long_press.py
@@ -42,7 +42,6 @@ def test_asset_grid_long_press_emits_preview(qapp: QApplication) -> None:
     release_spy = QSignalSpy(grid.previewReleased)
 
     QTest.mousePress(grid.viewport(), Qt.MouseButton.LeftButton, pos=pos)
-    QTest.qWait(LONG_PRESS_THRESHOLD_MS + 50)
-    assert preview_spy.wait(200)
+    assert preview_spy.wait(LONG_PRESS_THRESHOLD_MS + 800)
     QTest.mouseRelease(grid.viewport(), Qt.MouseButton.LeftButton, pos=pos)
     assert release_spy.wait(200)


### PR DESCRIPTION
## Summary
- normalise mouse event coordinates before resolving the pressed index
- fall back to global coordinates when the originating widget is unknown

## Testing
- pytest tests/test_asset_grid_long_press.py *(skipped: Qt widgets not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e27673be88832fb88776d4a623cb61