### PR TITLE
Fix automatic Live Photo pairing during rescans

### DIFF
--- a/src/iPhoto/gui/facade.py
+++ b/src/iPhoto/gui/facade.py
@@ -59,6 +59,7 @@ class AppFacade(QObject):
             self.errorRaised.emit(str(exc))
             return []
         self.indexUpdated.emit(album.root)
+        self.linksUpdated.emit(album.root)
         return rows
 
     def pair_live_current(self) -> List[dict]:

--- a/src/iPhoto/io/scanner.py
+++ b/src/iPhoto/io/scanner.py
@@ -50,8 +50,13 @@ def _build_row(root: Path, file_path: Path) -> Dict[str, Any]:
         "mime": mimetypes.guess_type(file_path.name)[0],
     }
     lower = file_path.suffix.lower()
+    metadata: Dict[str, Any] = {}
     if lower in {".heic", ".jpg", ".jpeg", ".png"}:
-        base_row.update(read_image_meta(file_path))
+        metadata = read_image_meta(file_path)
     elif lower in {".mov", ".mp4", ".m4v", ".qt"}:
-        base_row.update(read_video_meta(file_path))
+        metadata = read_video_meta(file_path)
+    for key, value in metadata.items():
+        if value is None and key in base_row:
+            continue
+        base_row[key] = value
     return base_row

--- a/tests/test_gui_app.py
+++ b/tests/test_gui_app.py
@@ -56,6 +56,17 @@ def test_facade_open_album_emits_signals(tmp_path: Path, qapp: QApplication) -> 
     assert "opened" in received and "index" in received
 
 
+def test_facade_rescan_emits_links(tmp_path: Path, qapp: QApplication) -> None:
+    asset = tmp_path / "IMG_1101.JPG"
+    _create_image(asset)
+    facade = AppFacade()
+    facade.open_album(tmp_path)
+    spy = QSignalSpy(facade.linksUpdated)
+    facade.rescan_current()
+    qapp.processEvents()
+    assert len(spy) >= 1
+
+
 def test_asset_model_populates_rows(tmp_path: Path, qapp: QApplication) -> None:
     asset = tmp_path / "IMG_2001.JPG"
     _create_image(asset)

--- a/tests/test_pairing_live.py
+++ b/tests/test_pairing_live.py
@@ -1,12 +1,27 @@
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 
+import pytest
+
+from iPhotos.src.iPhoto import app as backend
+from iPhotos.src.iPhoto.config import WORK_DIR_NAME
 from iPhotos.src.iPhoto.core.pairing import pair_live
+from iPhotos.src.iPhoto.utils.jsonio import read_json
 
 
 def iso(ts: datetime) -> str:
     return ts.replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _create_image(path: Path) -> None:
+    image_module = pytest.importorskip(
+        "PIL.Image", reason="Pillow is required to generate test images"
+    )
+    image = image_module.new("RGB", (8, 8), color="white")
+    image.save(path)
 
 
 def test_pairing_prefers_content_id() -> None:
@@ -33,3 +48,27 @@ def test_pairing_prefers_content_id() -> None:
     assert group.still == "IMG_0001.HEIC"
     assert group.motion == "IMG_0001.MOV"
     assert group.content_id == "CID1"
+
+
+def test_rescan_pairs_new_live_assets(tmp_path: Path) -> None:
+    still = tmp_path / "IMG_5001.JPG"
+    _create_image(still)
+
+    # Initial scan without the motion component creates an empty links cache.
+    backend.open_album(tmp_path)
+    links_path = tmp_path / WORK_DIR_NAME / "links.json"
+    initial = read_json(links_path)
+    assert initial.get("live_groups") == []
+
+    # Add the matching motion file and force a rescan to rebuild the cache.
+    motion = tmp_path / "IMG_5001.MOV"
+    motion.write_bytes(b"\x00")
+    ts = still.stat().st_mtime
+    os.utime(motion, (ts, ts))
+
+    backend.rescan(tmp_path)
+    updated = read_json(links_path)
+    assert any(
+        group.get("still") == "IMG_5001.JPG" and group.get("motion") == "IMG_5001.MOV"
+        for group in updated.get("live_groups", [])
+    )


### PR DESCRIPTION
## Summary
- rebuild the Live Photo links cache when rescanning and avoid rewriting unchanged data
- preserve filesystem timestamps when image metadata lacks capture time so pairing can succeed
- emit GUI link updates after rescans and add regression tests covering the new behavior

## Testing
- pytest tests/test_pairing_live.py tests/test_gui_app.py

------
https://chatgpt.com/codex/tasks/task_e_68e2b4e130f8832fbfd8e2a210a50639